### PR TITLE
`25.08` changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   },
   "engines": {
-    "node": "22.x"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "npm run generate && npm run compile",

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,6 +1,6 @@
-import * as path from "node:path";
-import * as process from "node:process";
-import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+import * as process from 'node:process';
+import { exec } from 'node:child_process';
 import { generateApi } from 'swagger-typescript-api';
 
 const schemas = {
@@ -46,15 +46,18 @@ Promise.all(
     }
   }),
 ).then(() => {
-  execFile(path.resolve(process.cwd(), 'scripts', 'fix-types.sh'), (error, _stdout, stderr) => {
-    if (error) {
-      console.error(`❌ Error while running 'fix-types.sh': ${error.message}`);
-      return;
-    }
-    if (stderr) {
-      console.error(`❌ Standard error output from fix-types.sh script: ${stderr}`);
-      return;
-    }
-    console.log('✅ Successfully fixed broken types');
-  });
+  exec(
+    'docker run --rm -v $(pwd):/app -w /app node:22-slim bash scripts/fix-types.sh',
+    (error, _stdout, stderr) => {
+      if (error) {
+        console.error(`❌ Error while running 'fix-types.sh': ${error.message}`);
+        return;
+      }
+      if (stderr) {
+        console.error(`❌ Standard error output from fix-types.sh script: ${stderr}`);
+        return;
+      }
+      console.log('✅ Successfully fixed broken types');
+    },
+  );
 });

--- a/src/schemas/confd.ts
+++ b/src/schemas/confd.ts
@@ -280,6 +280,12 @@
    */
     simultaneous_calls?: number,
   /**
+   * The subscription type of the user (0-10)
+   * @min 0
+   * @max 10
+   */
+    subscription_type?: number,
+  /**
    * Activate presence sharing in the xivo client
    * @default true
    */
@@ -1905,6 +1911,11 @@
    * @default true
    */
     enabled?: boolean,
+  /**
+   * Ignore forward when the group is in use
+   * @default false
+   */
+    ignore_forward?: boolean,
   /**
    * Mark all calls as "answered elsewhere" when cancelled
    * @default false
@@ -4917,6 +4928,12 @@
    * @default 5
    */
     simultaneous_calls?: number,
+  /**
+   * The subscription type of the user (0-10)
+   * @min 0
+   * @max 10
+   */
+    subscription_type?: number,
   /**
    * Activate presence sharing in the xivo client
    * @default true

--- a/src/schemas/setupd.ts
+++ b/src/schemas/setupd.ts
@@ -75,6 +75,11 @@ export interface SetupRequest {
   /** Name of the engine in Nestbox */
   nestbox_instance_name?: string;
   /**
+   * Preferred connection method to contact the engine
+   * @default "public"
+   */
+  nestbox_instance_preferred_connection?: "private" | "public";
+  /**
    * Port of the Nestbox where the engine will register
    * @default 443
    */


### PR DESCRIPTION
## Summary

- Run fix-types from docker image (mac compatibility issue with `sed`)
- Update schema to support `25.08` changes
- match `wazo-js-sdk` node requirements