### PR TITLE
Update types for 26.04.1

### DIFF
--- a/src/schemas/accessdPortal.ts
+++ b/src/schemas/accessdPortal.ts
@@ -219,7 +219,7 @@ export type ListSubscriptionAuthorizationsData = MainAuthorizationList;
 export interface ListSubscriptionAuthorizationsParams {
   /** The status of the authorization. Possible values are: OPEN, REVOKED */
   status?: string;
-  /** The UUID of the subscription */
+  /** The UUID of the subscription. */
   subscriptionUuid: string;
 }
 
@@ -843,7 +843,7 @@ export namespace Subscriptions {
    */
   export namespace DeleteSubscription {
     export type RequestParams = {
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};
@@ -865,7 +865,7 @@ export namespace Subscriptions {
    */
   export namespace GetSubscription {
     export type RequestParams = {
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};
@@ -887,7 +887,7 @@ export namespace Subscriptions {
    */
   export namespace UpdateSubscription {
     export type RequestParams = {
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};
@@ -909,7 +909,7 @@ export namespace Subscriptions {
    */
   export namespace ListSubscriptionAuthorizations {
     export type RequestParams = {
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {
@@ -934,7 +934,7 @@ export namespace Subscriptions {
    */
   export namespace CreateSubscriptionAuthorization {
     export type RequestParams = {
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};
@@ -958,7 +958,7 @@ export namespace Subscriptions {
     export type RequestParams = {
       /** The UUID of the authorization */
       authorizationUuid: string;
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};
@@ -982,7 +982,7 @@ export namespace Subscriptions {
     export type RequestParams = {
       /** The UUID of the authorization */
       authorizationUuid: string;
-      /** The UUID of the subscription */
+      /** The UUID of the subscription. */
       subscriptionUuid: string;
     };
     export type RequestQuery = {};

--- a/src/schemas/agentd.ts
+++ b/src/schemas/agentd.ts
@@ -112,6 +112,10 @@ export type LoginAgentByNumberData = any;
 
 export type LoginAgentByNumberError = Error;
 
+export type LoginAgentToQueueData = any;
+
+export type LoginAgentToQueueError = Error;
+
 /** Login information */
 export interface LoginInfo {
   /** Context */
@@ -134,6 +138,10 @@ export type LogoffAgentByNumberData = any;
 
 export type LogoffAgentByNumberError = Error;
 
+export type LogoffAgentFromQueueData = any;
+
+export type LogoffAgentFromQueueError = Error;
+
 export type LogoffAgentsData = any;
 
 export type LogoffUserAgentData = any;
@@ -155,6 +163,14 @@ export interface Queue {
 }
 
 export type RelogAgentsData = any;
+
+export interface RelogAgentsParams {
+  /**
+   * If true, relog each agent into all of its assigned queues, restoring membership for queues from which the agent was previously logged off individually.
+   * @default false
+   */
+  all_queues?: boolean;
+}
 
 export type RemoveAgentByIdData = any;
 
@@ -220,7 +236,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-id.{agent_id}.read`
-   * @tags agent
+   * @tags agents
    * @name GetAgentById
    * @summary Get agent status.
    * @request GET:/agents/by-id/{agent_id}
@@ -242,7 +258,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-id.{agent_id}.add.create`
-   * @tags agent
+   * @tags agents
    * @name AddAgentById
    * @summary Add agent to a queue.
    * @request POST:/agents/by-id/{agent_id}/add
@@ -264,7 +280,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-id.{agent_id}.login.create`
-   * @tags agent
+   * @tags agents
    * @name LoginAgentById
    * @summary Log an agent.
    * @request POST:/agents/by-id/{agent_id}/login
@@ -286,7 +302,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-id.{agent_id}.logoff.create`
-   * @tags agent
+   * @tags agents
    * @name LogoffAgentById
    * @summary Logoff an agent.
    * @request POST:/agents/by-id/{agent_id}/logoff
@@ -308,7 +324,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-id.{agent_id}.remove.create`
-   * @tags agent
+   * @tags agents
    * @name RemoveAgentById
    * @summary Remove agent from a queue.
    * @request POST:/agents/by-id/{agent_id}/remove
@@ -330,7 +346,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-number.{agent_number}.read`
-   * @tags agent
+   * @tags agents
    * @name GetAgentByNumber
    * @summary Get agent status.
    * @request GET:/agents/by-number/{agent_number}
@@ -352,7 +368,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-number.{agent_number}.login.create`
-   * @tags agent
+   * @tags agents
    * @name LoginAgentByNumber
    * @summary Log an agent.
    * @request POST:/agents/by-number/{agent_number}/login
@@ -374,7 +390,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-number.{agent_number}.logoff.create`
-   * @tags agent
+   * @tags agents
    * @name LogoffAgentByNumber
    * @summary Logoff an agent.
    * @request POST:/agents/by-number/{agent_number}/logoff
@@ -396,7 +412,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-number.{agent_number}.pause.create`
-   * @tags agent
+   * @tags agents
    * @name PauseAgentByNumber
    * @summary Pause an agent.
    * @request POST:/agents/by-number/{agent_number}/pause
@@ -418,7 +434,7 @@ export namespace Agents {
 
   /**
    * @description **Required ACL:** `agentd.agents.by-number.{agent_number}.unpause.create`
-   * @tags agent
+   * @tags agents
    * @name UnpauseAgentByNumber
    * @summary Unpause an agent.
    * @request POST:/agents/by-number/{agent_number}/unpause
@@ -467,13 +483,67 @@ export namespace Agents {
    */
   export namespace RelogAgents {
     export type RequestParams = {};
-    export type RequestQuery = {};
+    export type RequestQuery = {
+      /**
+       * If true, relog each agent into all of its assigned queues, restoring membership for queues from which the agent was previously logged off individually.
+       * @default false
+       */
+      all_queues?: boolean;
+    };
     export type RequestBody = never;
     export type RequestHeaders = {
       /** The tenant's UUID, defining the ownership of a given resource. */
       "Wazo-Tenant"?: string;
     };
     export type ResponseBody = RelogAgentsData;
+  }
+
+  /**
+   * @description **Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.login.update`
+   * @tags agents
+   * @name LoginAgentToQueue
+   * @summary Login agent to queue
+   * @request PUT:/agents/{agent_id}/queues/{queue_id}/login
+   * @secure
+   */
+  export namespace LoginAgentToQueue {
+    export type RequestParams = {
+      /** Agent's ID */
+      agentId: number;
+      /** Queue's ID */
+      queueId: number;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = LoginAgentToQueueData;
+  }
+
+  /**
+   * @description **Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.logoff.update`
+   * @tags agents
+   * @name LogoffAgentFromQueue
+   * @summary Logoff agent from queue
+   * @request PUT:/agents/{agent_id}/queues/{queue_id}/logoff
+   * @secure
+   */
+  export namespace LogoffAgentFromQueue {
+    export type RequestParams = {
+      /** Agent's ID */
+      agentId: number;
+      /** Queue's ID */
+      queueId: number;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = LogoffAgentFromQueueData;
   }
 }
 
@@ -498,7 +568,7 @@ export namespace Status {
 export namespace Users {
   /**
    * @description **Required ACL:** `agentd.users.me.agents.read`
-   * @tags agent, user
+   * @tags agents, users
    * @name GetUserAgent
    * @summary Get agent status of the user holding the authentication token.
    * @request GET:/users/me/agents
@@ -517,7 +587,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.login.create`
-   * @tags agent, user
+   * @tags agents, users
    * @name LoginUserAgent
    * @summary Log the agent of the user holding the authentication token
    * @request POST:/users/me/agents/login
@@ -536,7 +606,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.logoff.create`
-   * @tags agent, user
+   * @tags agents, users
    * @name LogoffUserAgent
    * @summary Logoff the agent of the user holding the authentication token
    * @request POST:/users/me/agents/logoff
@@ -555,7 +625,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.pause.create`
-   * @tags agent, user
+   * @tags agents, users
    * @name PauseUserAgent
    * @summary Pause the agent of the user holding the authentication token
    * @request POST:/users/me/agents/pause
@@ -574,7 +644,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.queues.{queue_id}.login.update`
-   * @tags agent, user
+   * @tags agents, users
    * @name UserAgentLoginToQueue
    * @summary Login user agent to queue
    * @request PUT:/users/me/agents/queues/{queue_id}/login
@@ -596,7 +666,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.queues.{queue_id}.logoff.update`
-   * @tags agent, user
+   * @tags agents, users
    * @name UserAgentLogoffFromQueue
    * @summary Logoff user agent from queue
    * @request PUT:/users/me/agents/queues/{queue_id}/logoff
@@ -618,7 +688,7 @@ export namespace Users {
 
   /**
    * @description **Required ACL:** `agentd.users.me.agents.unpause.create`
-   * @tags agent, user
+   * @tags agents, users
    * @name UnpauseUserAgent
    * @summary Unpause the agent of the user holding the authentication token
    * @request POST:/users/me/agents/unpause

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -302,6 +302,18 @@ export interface ExternalConfig {
   use_sandbox?: boolean;
 }
 
+export type ExternalGoogleCreateData = GooglePostResult;
+
+export type ExternalGoogleCreateError = APIError;
+
+export type ExternalGoogleDeleteData = any;
+
+export type ExternalGoogleDeleteError = APIError;
+
+export type ExternalGoogleListData = GoogleGetResult;
+
+export type ExternalGoogleListError = APIError;
+
 export type ExternalListData = ExternalAuthList;
 
 export interface ExternalListParams {
@@ -321,6 +333,39 @@ export interface ExternalListParams {
   /** The UUID of the user */
   userUuid: string;
 }
+
+export type ExternalMicrosoftCreateData = MicrosoftPostResult;
+
+export type ExternalMicrosoftCreateError = APIError;
+
+export type ExternalMicrosoftDeleteData = any;
+
+export type ExternalMicrosoftDeleteError = APIError;
+
+export type ExternalMicrosoftListData = MicrosoftGetResult;
+
+export type ExternalMicrosoftListError = APIError;
+
+export type ExternalMobileCreateData = MobileData;
+
+export type ExternalMobileCreateError = APIError;
+
+export type ExternalMobileDeleteData = any;
+
+export type ExternalMobileListData = MobileData;
+
+export type ExternalMobileListError = APIError;
+
+export interface ExternalMobileSenderIdListData {
+  /** The sender id */
+  sender_id?: string | null;
+}
+
+export type ExternalMobileSenderIdListError = APIError;
+
+export type ExternalMobileUpdateData = MobileData;
+
+export type ExternalMobileUpdateError = APIError;
 
 export type GetConfigData = any;
 
@@ -357,6 +402,28 @@ export interface GetSessionsResult {
   items: SessionResult[];
   /** The number of sessions. */
   total: number;
+}
+
+export interface GoogleGetResult {
+  /** Google token */
+  access_token: string;
+  /** Scope permissions given to the `access token` */
+  scope: string;
+  /** Token expiration */
+  token_expiration: number;
+}
+
+export interface GooglePost {
+  /**
+   * Scope permissions requested
+   * @default ["https://www.googleapis.com/auth/userinfo.profile","https://www.googleapis.com/auth/contacts"]
+   */
+  scope?: string[];
+}
+
+export interface GooglePostResult {
+  /** The URL to confirm the authorization */
+  verification_url: string;
 }
 
 export interface Group {
@@ -520,9 +587,9 @@ export interface ListGroupsParams {
   offset?: number;
   /** Name of the field to use for sorting the list of items returned. */
   order?: string;
-  /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The slug of the policy that the group must have. */
   policy_slug?: string;
-  /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The UUID of the policy that the group must have. */
   policy_uuid?: string;
   /** Is the group managed by the system? */
   read_only?: string;
@@ -628,6 +695,43 @@ export interface ListUserRefreshTokensParams {
   search?: string;
   /** The UUID of the user or `me` to refer to the user doing the query */
   userUuidOrMe: string;
+}
+
+export interface MicrosoftGetResult {
+  /** Microsoft token */
+  access_token: string;
+  /** Scope permissions given to the `access token` */
+  scope: string;
+  /** Token expiration */
+  token_expiration: number;
+}
+
+export interface MicrosoftPost {
+  /**
+   * Scope permissions requested
+   * @default ["offline_access","Contacts.Read"]
+   */
+  scope?: string[];
+}
+
+export interface MicrosoftPostResult {
+  /** The URL to confirm the authorization */
+  verification_url: string;
+}
+
+export interface MobileData {
+  /** APNs topic for VoIP call notifications (e.g. com.example.app.voip). When set, overrides the server-wide mobile_apns_call_topic configuration. */
+  apns_call_topic?: string;
+  /** APNs topic for non-call notifications such as messages, voicemails, and missed calls (e.g. com.example.app). When set, overrides the server-wide mobile_apns_default_topic configuration. */
+  apns_default_topic?: string;
+  /** APNs text alert notification device token. */
+  apns_notification_token?: string;
+  /** APNs VoIP device token. This field is deprecated and will be removed in a later version. */
+  apns_token?: string;
+  /** APNs VoIP device token. */
+  apns_voip_token?: string;
+  /** FCM token */
+  token?: string;
 }
 
 export interface PasswordChange {
@@ -805,13 +909,6 @@ export interface SAMLBackendConfig {
   entity_id: string;
 }
 
-export interface SAMLIdpLogoutResponse {
-  /** Relay state parameter */
-  RelayState: string;
-  /** Encoded SAML XML response to logout request */
-  SAMLLogoutResponse: string;
-}
-
 export interface SAMLIdpResponse {
   /** Relay state parameter */
   RelayState: string;
@@ -851,6 +948,13 @@ export type SamlAcsUrlTemplateListError = Error;
 export type SamlLogoutData = SAMLLogoutRequest;
 
 export type SamlLogoutResponseData = any;
+
+export interface SamlLogoutResponseParams {
+  /** Relay state parameter */
+  RelayState: string;
+  /** Encoded SAML XML response to logout request */
+  SAMLResponse: string;
+}
 
 /**
  * The  metadata file in XML format.
@@ -1236,9 +1340,9 @@ export interface UsersListParams4 {
   offset?: number;
   /** Name of the field to use for sorting the list of items returned. */
   order?: string;
-  /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The slug of the policy that the group must have. */
   policy_slug?: string;
-  /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The UUID of the policy that the group must have. */
   policy_uuid?: string;
   /**
    * Should the query include sub-tenants
@@ -1676,9 +1780,9 @@ export namespace Groups {
       offset?: number;
       /** Name of the field to use for sorting the list of items returned. */
       order?: string;
-      /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The slug of the policy that the group must have. */
       policy_slug?: string;
-      /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The UUID of the policy that the group must have. */
       policy_uuid?: string;
       /** Is the group managed by the system? */
       read_only?: string;
@@ -2223,7 +2327,7 @@ failed to allow further processing by the frontend application.
   }
 
   /**
-   * @description Processes the IdP response to logout request and confirms the logout by a redirect to the `redirect_url` provided during the login phase with logout confirmation un the URL's query param.
+   * @description Processes the IdP response to logout request and confirms the logout by a redirect to the `redirect_url` provided during the login phase with logout confirmation in the URL's query param.
    * @tags token, saml
    * @name SamlLogoutResponse
    * @summary Handles the logout response from the IDP
@@ -2231,8 +2335,13 @@ failed to allow further processing by the frontend application.
    */
   export namespace SamlLogoutResponse {
     export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = SAMLIdpLogoutResponse;
+    export type RequestQuery = {
+      /** Relay state parameter */
+      RelayState: string;
+      /** Encoded SAML XML response to logout request */
+      SAMLResponse: string;
+    };
+    export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = SamlLogoutResponseData;
   }
@@ -2648,9 +2757,9 @@ export namespace Users {
       offset?: number;
       /** Name of the field to use for sorting the list of items returned. */
       order?: string;
-      /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The slug of the policy that the group must have. */
       policy_slug?: string;
-      /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The UUID of the policy that the group must have. */
       policy_uuid?: string;
       /**
        * Should the query include sub-tenants
@@ -2926,6 +3035,204 @@ export namespace Users {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = ExternalListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.delete`
+   * @tags users, google
+   * @name ExternalGoogleDelete
+   * @summary Delete a Google token
+   * @request DELETE:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.read`
+   * @tags users, google
+   * @name ExternalGoogleList
+   * @summary Get a Google token
+   * @request GET:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.create`. More info on Google permissions: https://developers.google.com/identity/protocols/googlescopes"
+   * @tags users, google
+   * @name ExternalGoogleCreate
+   * @summary Ask for a verification URL and store code to get token
+   * @request POST:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = GooglePost;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.delete`
+   * @tags users, microsoft
+   * @name ExternalMicrosoftDelete
+   * @summary Delete a Microsoft token
+   * @request DELETE:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.read`
+   * @tags users, microsoft
+   * @name ExternalMicrosoftList
+   * @summary Get a Microsoft token
+   * @request GET:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.create`. More info on Microsoft permissions: https://docs.microsoft.com/en-us/graph/permissions-reference
+   * @tags users, microsoft
+   * @name ExternalMicrosoftCreate
+   * @summary Ask for a verification URL and store code to get token
+   * @request POST:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MicrosoftPost;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.delete`
+   * @tags users, mobile
+   * @name ExternalMobileDelete
+   * @summary Delete device tokens for push notifications
+   * @request DELETE:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.read`
+   * @tags users, mobile
+   * @name ExternalMobileList
+   * @summary Get device tokens for push notifications
+   * @request GET:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.create`
+   * @tags users, mobile
+   * @name ExternalMobileCreate
+   * @summary Configure device tokens for push notifications
+   * @request POST:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MobileData;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.update`
+   * @tags users, mobile
+   * @name ExternalMobileUpdate
+   * @summary Update device tokens for push notifications
+   * @request PUT:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileUpdate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MobileData;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileUpdateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.sender_id.read`
+   * @tags users, mobile
+   * @name ExternalMobileSenderIdList
+   * @summary Get your Mobile sender_id
+   * @request GET:/users/{user_uuid}/external/mobile/sender_id
+   */
+  export namespace ExternalMobileSenderIdList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileSenderIdListData;
   }
 
   /**

--- a/src/schemas/authPortal.ts
+++ b/src/schemas/authPortal.ts
@@ -302,6 +302,18 @@ export interface ExternalConfig {
   use_sandbox?: boolean;
 }
 
+export type ExternalGoogleCreateData = GooglePostResult;
+
+export type ExternalGoogleCreateError = APIError;
+
+export type ExternalGoogleDeleteData = any;
+
+export type ExternalGoogleDeleteError = APIError;
+
+export type ExternalGoogleListData = GoogleGetResult;
+
+export type ExternalGoogleListError = APIError;
+
 export type ExternalListData = ExternalAuthList;
 
 export interface ExternalListParams {
@@ -321,6 +333,39 @@ export interface ExternalListParams {
   /** The UUID of the user */
   userUuid: string;
 }
+
+export type ExternalMicrosoftCreateData = MicrosoftPostResult;
+
+export type ExternalMicrosoftCreateError = APIError;
+
+export type ExternalMicrosoftDeleteData = any;
+
+export type ExternalMicrosoftDeleteError = APIError;
+
+export type ExternalMicrosoftListData = MicrosoftGetResult;
+
+export type ExternalMicrosoftListError = APIError;
+
+export type ExternalMobileCreateData = MobileData;
+
+export type ExternalMobileCreateError = APIError;
+
+export type ExternalMobileDeleteData = any;
+
+export type ExternalMobileListData = MobileData;
+
+export type ExternalMobileListError = APIError;
+
+export interface ExternalMobileSenderIdListData {
+  /** The sender id */
+  sender_id?: string | null;
+}
+
+export type ExternalMobileSenderIdListError = APIError;
+
+export type ExternalMobileUpdateData = MobileData;
+
+export type ExternalMobileUpdateError = APIError;
 
 export type GetConfigData = any;
 
@@ -357,6 +402,28 @@ export interface GetSessionsResult {
   items: SessionResult[];
   /** The number of sessions. */
   total: number;
+}
+
+export interface GoogleGetResult {
+  /** Google token */
+  access_token: string;
+  /** Scope permissions given to the `access token` */
+  scope: string;
+  /** Token expiration */
+  token_expiration: number;
+}
+
+export interface GooglePost {
+  /**
+   * Scope permissions requested
+   * @default ["https://www.googleapis.com/auth/userinfo.profile","https://www.googleapis.com/auth/contacts"]
+   */
+  scope?: string[];
+}
+
+export interface GooglePostResult {
+  /** The URL to confirm the authorization */
+  verification_url: string;
 }
 
 export interface Group {
@@ -520,9 +587,9 @@ export interface ListGroupsParams {
   offset?: number;
   /** Name of the field to use for sorting the list of items returned. */
   order?: string;
-  /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The slug of the policy that the group must have. */
   policy_slug?: string;
-  /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The UUID of the policy that the group must have. */
   policy_uuid?: string;
   /** Is the group managed by the system? */
   read_only?: string;
@@ -628,6 +695,43 @@ export interface ListUserRefreshTokensParams {
   search?: string;
   /** The UUID of the user or `me` to refer to the user doing the query */
   userUuidOrMe: string;
+}
+
+export interface MicrosoftGetResult {
+  /** Microsoft token */
+  access_token: string;
+  /** Scope permissions given to the `access token` */
+  scope: string;
+  /** Token expiration */
+  token_expiration: number;
+}
+
+export interface MicrosoftPost {
+  /**
+   * Scope permissions requested
+   * @default ["offline_access","Contacts.Read"]
+   */
+  scope?: string[];
+}
+
+export interface MicrosoftPostResult {
+  /** The URL to confirm the authorization */
+  verification_url: string;
+}
+
+export interface MobileData {
+  /** APNs topic for VoIP call notifications (e.g. com.example.app.voip). When set, overrides the server-wide mobile_apns_call_topic configuration. */
+  apns_call_topic?: string;
+  /** APNs topic for non-call notifications such as messages, voicemails, and missed calls (e.g. com.example.app). When set, overrides the server-wide mobile_apns_default_topic configuration. */
+  apns_default_topic?: string;
+  /** APNs text alert notification device token. */
+  apns_notification_token?: string;
+  /** APNs VoIP device token. This field is deprecated and will be removed in a later version. */
+  apns_token?: string;
+  /** APNs VoIP device token. */
+  apns_voip_token?: string;
+  /** FCM token */
+  token?: string;
 }
 
 export interface PasswordChange {
@@ -805,13 +909,6 @@ export interface SAMLBackendConfig {
   entity_id: string;
 }
 
-export interface SAMLIdpLogoutResponse {
-  /** Relay state parameter */
-  RelayState: string;
-  /** Encoded SAML XML response to logout request */
-  SAMLLogoutResponse: string;
-}
-
 export interface SAMLIdpResponse {
   /** Relay state parameter */
   RelayState: string;
@@ -851,6 +948,13 @@ export type SamlAcsUrlTemplateListError = Error;
 export type SamlLogoutData = SAMLLogoutRequest;
 
 export type SamlLogoutResponseData = any;
+
+export interface SamlLogoutResponseParams {
+  /** Relay state parameter */
+  RelayState: string;
+  /** Encoded SAML XML response to logout request */
+  SAMLResponse: string;
+}
 
 /**
  * The  metadata file in XML format.
@@ -1236,9 +1340,9 @@ export interface UsersListParams4 {
   offset?: number;
   /** Name of the field to use for sorting the list of items returned. */
   order?: string;
-  /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The slug of the policy that the group must have. */
   policy_slug?: string;
-  /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+  /** The UUID of the policy that the group must have. */
   policy_uuid?: string;
   /**
    * Should the query include sub-tenants
@@ -1676,9 +1780,9 @@ export namespace Groups {
       offset?: number;
       /** Name of the field to use for sorting the list of items returned. */
       order?: string;
-      /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The slug of the policy that the group must have. */
       policy_slug?: string;
-      /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The UUID of the policy that the group must have. */
       policy_uuid?: string;
       /** Is the group managed by the system? */
       read_only?: string;
@@ -2223,7 +2327,7 @@ failed to allow further processing by the frontend application.
   }
 
   /**
-   * @description Processes the IdP response to logout request and confirms the logout by a redirect to the `redirect_url` provided during the login phase with logout confirmation un the URL's query param.
+   * @description Processes the IdP response to logout request and confirms the logout by a redirect to the `redirect_url` provided during the login phase with logout confirmation in the URL's query param.
    * @tags token, saml
    * @name SamlLogoutResponse
    * @summary Handles the logout response from the IDP
@@ -2231,8 +2335,13 @@ failed to allow further processing by the frontend application.
    */
   export namespace SamlLogoutResponse {
     export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = SAMLIdpLogoutResponse;
+    export type RequestQuery = {
+      /** Relay state parameter */
+      RelayState: string;
+      /** Encoded SAML XML response to logout request */
+      SAMLResponse: string;
+    };
+    export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = SamlLogoutResponseData;
   }
@@ -2648,9 +2757,9 @@ export namespace Users {
       offset?: number;
       /** Name of the field to use for sorting the list of items returned. */
       order?: string;
-      /** The slug of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The slug of the policy that the group must have. */
       policy_slug?: string;
-      /** The UUID of the policy that the user must have. This does not include indirect associations (user in group has policy). */
+      /** The UUID of the policy that the group must have. */
       policy_uuid?: string;
       /**
        * Should the query include sub-tenants
@@ -2926,6 +3035,204 @@ export namespace Users {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = ExternalListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.delete`
+   * @tags users, google
+   * @name ExternalGoogleDelete
+   * @summary Delete a Google token
+   * @request DELETE:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.read`
+   * @tags users, google
+   * @name ExternalGoogleList
+   * @summary Get a Google token
+   * @request GET:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.google.create`. More info on Google permissions: https://developers.google.com/identity/protocols/googlescopes"
+   * @tags users, google
+   * @name ExternalGoogleCreate
+   * @summary Ask for a verification URL and store code to get token
+   * @request POST:/users/{user_uuid}/external/google
+   */
+  export namespace ExternalGoogleCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = GooglePost;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalGoogleCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.delete`
+   * @tags users, microsoft
+   * @name ExternalMicrosoftDelete
+   * @summary Delete a Microsoft token
+   * @request DELETE:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.read`
+   * @tags users, microsoft
+   * @name ExternalMicrosoftList
+   * @summary Get a Microsoft token
+   * @request GET:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.microsoft.create`. More info on Microsoft permissions: https://docs.microsoft.com/en-us/graph/permissions-reference
+   * @tags users, microsoft
+   * @name ExternalMicrosoftCreate
+   * @summary Ask for a verification URL and store code to get token
+   * @request POST:/users/{user_uuid}/external/microsoft
+   */
+  export namespace ExternalMicrosoftCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MicrosoftPost;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMicrosoftCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.delete`
+   * @tags users, mobile
+   * @name ExternalMobileDelete
+   * @summary Delete device tokens for push notifications
+   * @request DELETE:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileDelete {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileDeleteData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.read`
+   * @tags users, mobile
+   * @name ExternalMobileList
+   * @summary Get device tokens for push notifications
+   * @request GET:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileListData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.create`
+   * @tags users, mobile
+   * @name ExternalMobileCreate
+   * @summary Configure device tokens for push notifications
+   * @request POST:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileCreate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MobileData;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileCreateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.update`
+   * @tags users, mobile
+   * @name ExternalMobileUpdate
+   * @summary Update device tokens for push notifications
+   * @request PUT:/users/{user_uuid}/external/mobile
+   */
+  export namespace ExternalMobileUpdate {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = MobileData;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileUpdateData;
+  }
+
+  /**
+   * @description **Required ACL**: `auth.users.{user_uuid}.external.mobile.sender_id.read`
+   * @tags users, mobile
+   * @name ExternalMobileSenderIdList
+   * @summary Get your Mobile sender_id
+   * @request GET:/users/{user_uuid}/external/mobile/sender_id
+   */
+  export namespace ExternalMobileSenderIdList {
+    export type RequestParams = {
+      /** The UUID of the user */
+      userUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ExternalMobileSenderIdListData;
   }
 
   /**

--- a/src/schemas/callLogd.ts
+++ b/src/schemas/callLogd.ts
@@ -10,11 +10,28 @@
  * ---------------------------------------------------------------
  */
 
+export interface AgentQueueStatistic {
+  /** Number of calls this agent answered on this queue */
+  answered?: number;
+  /** Time this agent spent in conversation on this queue, in seconds */
+  conversation_time?: number;
+  /** Time this agent was logged in to this queue, in seconds */
+  login_time?: number;
+  /** Time this agent spent in pause on this queue, in seconds */
+  pause_time?: number;
+  /** ID of the queue. */
+  queue_id?: number;
+  /** Time this agent spent in wrap-up after calls on this queue, in seconds */
+  wrapup_time?: number;
+}
+
 export interface AgentStatistic {
   /** ID of the corresponding agent. */
   agent_id?: number;
   /** The number of this agent */
   agent_number?: string;
+  /** The number of answered calls */
+  answered?: number;
   /** The time spent in conversation in seconds */
   conversation_time?: number;
   /** Start of the statistic interval. */
@@ -23,6 +40,8 @@ export interface AgentStatistic {
   login_time?: number;
   /** The time spent in pause in seconds */
   pause_time?: number;
+  /** Per-queue breakdown of agent activity over this interval */
+  queues?: AgentQueueStatistic[];
   /**
    * Tenant UUID of the corresponding queue.
    * @format uuid
@@ -51,14 +70,17 @@ export interface CDR {
   call_direction?: "inbound" | "internal" | "outbound";
   call_status?: CallStatus;
   conversation_id?: string;
-  /** Contains the `type` of the called destination; which can be either `user`, `conference`, `meeting`, or `unknown` by default. Also contains useful information about the destination (`id` and `name`). */
+  /** Contains the `type` of the called destination; which can be either `user`, `conference`, `meeting`, `group` or `unknown` by default. Also contains useful information about the destination (`id` and `name`). */
   destination_details?: object;
+  /** extension of the party that answered the call */
   destination_extension?: string;
+  /** internal context of the line that answered the call, or the first line to ring if unanswered */
   destination_internal_context?: string;
-  /** the internal extension of the line that answers */
+  /** internal extension of the line that answered the call, or the first line to ring if unanswered */
   destination_internal_extension?: string;
   destination_internal_tenant_uuid?: string;
   destination_line_id?: number;
+  /** name of the party that answered the call */
   destination_name?: string;
   destination_tenant_uuid?: string;
   destination_user_uuid?: string;
@@ -68,12 +90,16 @@ export interface CDR {
   end?: string;
   id?: number;
   recordings?: Recording[];
+  /** dialplan context of the dialed extension */
   requested_context?: string;
+  /** extension dialed by the caller */
   requested_extension?: string;
+  /** internal context of the first line to ring */
   requested_internal_context?: string;
-  /** the internal extension of the first line to ring */
+  /** internal extension of the first line to ring */
   requested_internal_extension?: string;
   requested_internal_tenant_uuid?: string;
+  /** name of the intended recipient as dialed */
   requested_name?: string;
   requested_tenant_uuid?: string;
   requested_user_uuid?: string;
@@ -160,26 +186,26 @@ export interface GetCdrParams {
   call_status?: "answered" | "blocked";
   /** Filter by conversation identifier */
   conversation_id?: string;
-  /** Sort order direction */
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
   direction?: "asc" | "desc";
   /** Will only return one result for the selected field */
   distinct?: "peer_exten";
   /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
   format?: "csv" | "json";
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
   /** Ignore CDR created before the given CDR ID. */
   from_id?: number;
-  /** Maximum number of items to return */
+  /** Maximum number of items to return in the list. Default to 1000 if not specified. */
   limit?: number;
   /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
   number?: string;
-  /** Number of items to skip */
+  /** Number of items to skip over in the list. Useful for pagination. */
   offset?: number;
-  /** Name of the field to order by */
+  /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
   order?: "created_at" | "message_id";
   /** Filter by recorded status. */
   recorded?: boolean;
@@ -197,7 +223,7 @@ export interface GetCdrParams {
   /** Filter by tags. Each tag MUST be separated by a coma (,). Many tag will perform a logical AND. */
   tags?: string[];
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -216,26 +242,26 @@ export interface GetUsersParams {
   call_status?: "answered" | "blocked";
   /** Filter by conversation identifier */
   conversation_id?: string;
-  /** Sort order direction */
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
   direction?: "asc" | "desc";
   /** Will only return one result for the selected field */
   distinct?: "peer_exten";
   /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
   format?: "csv" | "json";
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
   /** Ignore CDR created before the given CDR ID. */
   from_id?: number;
-  /** Maximum number of items to return */
+  /** Maximum number of items to return in the list. Default to 1000 if not specified. */
   limit?: number;
   /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
   number?: string;
-  /** Number of items to skip */
+  /** Number of items to skip over in the list. Useful for pagination. */
   offset?: number;
-  /** Name of the field to order by */
+  /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
   order?: "created_at" | "message_id";
   /** Filter by recorded status. */
   recorded?: boolean;
@@ -246,7 +272,7 @@ export interface GetUsersParams {
   /** Filter list of items */
   search?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -257,23 +283,23 @@ export interface GetUsersParams {
 export type ListVoicemailTranscriptionsData = TranscriptionList;
 
 export interface ListVoicemailTranscriptionsParams {
-  /** Sort order direction */
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
   direction?: "asc" | "desc";
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
-  /** Maximum number of items to return */
+  /** Maximum number of items to return in the list. Default to 1000 if not specified. */
   limit?: number;
-  /** Number of items to skip */
+  /** Number of items to skip over in the list. Useful for pagination. */
   offset?: number;
-  /** Name of the field to order by */
+  /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
   order?: "created_at" | "message_id";
   /** Full-text search in transcript content */
   search_text?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -290,26 +316,26 @@ export interface MeCdrListParams {
   call_status?: "answered" | "blocked";
   /** Filter by conversation identifier */
   conversation_id?: string;
-  /** Sort order direction */
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
   direction?: "asc" | "desc";
   /** Will only return one result for the selected field */
   distinct?: "peer_exten";
   /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
   format?: "csv" | "json";
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
   /** Ignore CDR created before the given CDR ID. */
   from_id?: number;
-  /** Maximum number of items to return */
+  /** Maximum number of items to return in the list. Default to 1000 if not specified. */
   limit?: number;
   /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
   number?: string;
-  /** Number of items to skip */
+  /** Number of items to skip over in the list. Useful for pagination. */
   offset?: number;
-  /** Name of the field to order by */
+  /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
   order?: "created_at" | "message_id";
   /** Filter by recorded status. */
   recorded?: boolean;
@@ -320,7 +346,7 @@ export interface MeCdrListParams {
   /** Filter list of items */
   search?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -445,7 +471,7 @@ export interface RecordingsMediaExportCreateParams {
   /** E-mail address */
   email?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -463,7 +489,7 @@ export interface RecordingsMediaExportCreateParams {
   /** Filter by tags. Each tag MUST be separated by a coma (,). Many tag will perform a logical AND. */
   tags?: string[];
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -500,7 +526,7 @@ export interface StatisticsList2Params {
   /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
   day_start_time?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -514,7 +540,7 @@ export interface StatisticsList2Params {
    */
   timezone?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -532,7 +558,7 @@ export interface StatisticsList2Params2 {
   /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
   day_start_time?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -550,7 +576,7 @@ export interface StatisticsList2Params2 {
    */
   timezone?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -572,7 +598,7 @@ export interface StatisticsListParams {
   /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
   day_start_time?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -584,7 +610,7 @@ export interface StatisticsListParams {
    */
   timezone?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -602,7 +628,7 @@ export interface StatisticsListParams2 {
   /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
   day_start_time?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -616,7 +642,7 @@ export interface StatisticsListParams2 {
    */
   timezone?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -638,7 +664,7 @@ export interface StatisticsQosListParams {
   /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
   day_start_time?: string;
   /**
-   * Filter transcriptions created after this date
+   * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   from?: string;
@@ -659,7 +685,7 @@ export interface StatisticsQosListParams {
    */
   timezone?: string;
   /**
-   * Filter transcriptions created before this date
+   * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
    * @format date-time
    */
   until?: string;
@@ -729,7 +755,7 @@ export namespace Agents {
       /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
       day_start_time?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -741,7 +767,7 @@ export namespace Agents {
        */
       timezone?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -781,7 +807,7 @@ export namespace Agents {
       /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
       day_start_time?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -795,7 +821,7 @@ export namespace Agents {
        */
       timezone?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -833,26 +859,26 @@ export namespace Cdr {
       call_status?: "answered" | "blocked";
       /** Filter by conversation identifier */
       conversation_id?: string;
-      /** Sort order direction */
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
       direction?: "asc" | "desc";
       /** Will only return one result for the selected field */
       distinct?: "peer_exten";
       /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
       format?: "csv" | "json";
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
       /** Ignore CDR created before the given CDR ID. */
       from_id?: number;
-      /** Maximum number of items to return */
+      /** Maximum number of items to return in the list. Default to 1000 if not specified. */
       limit?: number;
       /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
       number?: string;
-      /** Number of items to skip */
+      /** Number of items to skip over in the list. Useful for pagination. */
       offset?: number;
-      /** Name of the field to order by */
+      /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
       order?: "created_at" | "message_id";
       /** Filter by recorded status. */
       recorded?: boolean;
@@ -870,7 +896,7 @@ export namespace Cdr {
       /** Filter by tags. Each tag MUST be separated by a coma (,). Many tag will perform a logical AND. */
       tags?: string[];
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -917,7 +943,7 @@ export namespace Cdr {
       /** E-mail address */
       email?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -935,7 +961,7 @@ export namespace Cdr {
       /** Filter by tags. Each tag MUST be separated by a coma (,). Many tag will perform a logical AND. */
       tags?: string[];
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1113,7 +1139,7 @@ export namespace Queues {
       /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
       day_start_time?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -1127,7 +1153,7 @@ export namespace Queues {
        */
       timezone?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1167,7 +1193,7 @@ export namespace Queues {
       /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
       day_start_time?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -1183,7 +1209,7 @@ export namespace Queues {
        */
       timezone?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1221,7 +1247,7 @@ export namespace Queues {
       /** The time at which a day starts, inclusively. Accepted format is `HH:MM`, minutes are ignored. */
       day_start_time?: string;
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
@@ -1240,7 +1266,7 @@ export namespace Queues {
        */
       timezone?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1336,26 +1362,26 @@ export namespace Users {
       call_status?: "answered" | "blocked";
       /** Filter by conversation identifier */
       conversation_id?: string;
-      /** Sort order direction */
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
       direction?: "asc" | "desc";
       /** Will only return one result for the selected field */
       distinct?: "peer_exten";
       /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
       format?: "csv" | "json";
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
       /** Ignore CDR created before the given CDR ID. */
       from_id?: number;
-      /** Maximum number of items to return */
+      /** Maximum number of items to return in the list. Default to 1000 if not specified. */
       limit?: number;
       /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
       number?: string;
-      /** Number of items to skip */
+      /** Number of items to skip over in the list. Useful for pagination. */
       offset?: number;
-      /** Name of the field to order by */
+      /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
       order?: "created_at" | "message_id";
       /** Filter by recorded status. */
       recorded?: boolean;
@@ -1366,7 +1392,7 @@ export namespace Users {
       /** Filter list of items */
       search?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1425,26 +1451,26 @@ export namespace Users {
       call_status?: "answered" | "blocked";
       /** Filter by conversation identifier */
       conversation_id?: string;
-      /** Sort order direction */
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
       direction?: "asc" | "desc";
       /** Will only return one result for the selected field */
       distinct?: "peer_exten";
       /** Overrides the Content-Type header. This is used to be able to have a downloadable link. Allowed values are "csv" and "json" */
       format?: "csv" | "json";
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
       /** Ignore CDR created before the given CDR ID. */
       from_id?: number;
-      /** Maximum number of items to return */
+      /** Maximum number of items to return in the list. Default to 1000 if not specified. */
       limit?: number;
       /** Filter by source_extension and destination_extension. A wildcard (underscore) can be used at the start and/or the end of the number. */
       number?: string;
-      /** Number of items to skip */
+      /** Number of items to skip over in the list. Useful for pagination. */
       offset?: number;
-      /** Name of the field to order by */
+      /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
       order?: "created_at" | "message_id";
       /** Filter by recorded status. */
       recorded?: boolean;
@@ -1455,7 +1481,7 @@ export namespace Users {
       /** Filter list of items */
       search?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;
@@ -1478,23 +1504,23 @@ export namespace Voicemails {
   export namespace ListVoicemailTranscriptions {
     export type RequestParams = {};
     export type RequestQuery = {
-      /** Sort order direction */
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
       direction?: "asc" | "desc";
       /**
-       * Filter transcriptions created after this date
+       * Ignore CDR starting before the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       from?: string;
-      /** Maximum number of items to return */
+      /** Maximum number of items to return in the list. Default to 1000 if not specified. */
       limit?: number;
-      /** Number of items to skip */
+      /** Number of items to skip over in the list. Useful for pagination. */
       offset?: number;
-      /** Name of the field to order by */
+      /** Name of the field to use for sorting the list of items returned. Unsupported values: ``end``. */
       order?: "created_at" | "message_id";
       /** Full-text search in transcript content */
       search_text?: string;
       /**
-       * Filter transcriptions created before this date
+       * Ignore CDR starting at or after the given date. Format is <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>.
        * @format date-time
        */
       until?: string;

--- a/src/schemas/calld.ts
+++ b/src/schemas/calld.ts
@@ -22,6 +22,21 @@ export interface AdhocConferenceCreation {
   participant_call_ids?: string[];
 }
 
+export type AdminVoicemailMessage = VoicemailMessageBase & {
+  /** True if a transcription exists for this message */
+  transcribed?: boolean;
+};
+
+export interface AdminVoicemailMessages {
+  filtered?: number;
+  /** List of voicemail messages */
+  items?: (AdminVoicemailMessage & {
+    folder?: VoicemailFolderBase;
+    voicemail?: VoicemailMessageVoicemail;
+  })[];
+  total?: number;
+}
+
 export type AnswerUpdateData = any;
 
 export type AnswerUpdateError = Error;
@@ -228,7 +243,7 @@ export interface CallsDtmfUpdateParams {
 export type CallsHeldAnswerUpdateData = CallID;
 
 export interface CallsHeldAnswerUpdateParams {
-  /** Call ID */
+  /** ID of the call */
   callId: string;
   /** ID of the line of the user used to make the call. Default is the main line of the user. */
   line_id?: number;
@@ -299,7 +314,7 @@ export type CallsProgressStopUpdateError = Error;
 export type CallsQueuedAnswerUpdateData = CallID;
 
 export interface CallsQueuedAnswerUpdateParams {
-  /** Call ID */
+  /** ID of the call */
   callId: string;
   /** ID of the line of the user used to make the call. Default is the main line of the user. */
   line_id?: number;
@@ -342,7 +357,7 @@ export type DtmfUpdateData = any;
 export type DtmfUpdateError = Error;
 
 export interface DtmfUpdateParams {
-  /** Call ID */
+  /** ID of the call */
   callId: string;
   /** Digits to send via DTMF. Must contain only `0-9*#`. */
   digits: string;
@@ -513,7 +528,7 @@ export type MeCallsDtmfUpdateData = any;
 export type MeCallsDtmfUpdateError = Error;
 
 export interface MeCallsDtmfUpdateParams {
-  /** Call ID */
+  /** ID of the call */
   callId: string;
   /** Digits to send via DTMF. Must contain only `0-9*#`. */
   digits: string;
@@ -688,6 +703,45 @@ export interface MeetingStatus {
 export type MessagesDeleteData = any;
 
 export type MessagesDetailData = VoicemailMessage;
+
+export type MessagesListData = AdminVoicemailMessages;
+
+export interface MessagesListParams {
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
+  direction?: "asc" | "desc";
+  /**
+   * Filter messages with timestamp >= this value (ISO 8601 datetime)
+   * @format date-time
+   */
+  from?: string;
+  /** Maximum number of items to return in the list */
+  limit?: number;
+  /** Number of items to skip over in the list. Useful for pagination. */
+  offset?: number;
+  /** Name of the field to use for sorting the list of items returned. */
+  order?: string;
+  /**
+   * Include sub-tenants
+   * @default false
+   */
+  recurse?: boolean;
+  /** Filter messages by transcription availability */
+  transcribed?: boolean;
+  /**
+   * Filter messages with timestamp < this value (ISO 8601 datetime)
+   * @format date-time
+   */
+  until?: string;
+  /** Filter messages by user UUID (returns user's personal + global voicemails) */
+  user_uuid?: string;
+  /** Filter messages by voicemail ID */
+  voicemail_id?: number;
+  /**
+   * Filter messages by voicemail accesstype
+   * @default "all"
+   */
+  voicemail_type?: "all" | "personal" | "global";
+}
 
 export type MessagesRecordingListData = any;
 
@@ -1173,7 +1227,7 @@ export interface VoicemailFolderBase {
   type?: "new" | "old" | "urgent" | "other";
 }
 
-export type VoicemailMessage = VoicemailMessageBase & {
+export type VoicemailMessage = VoicemailTranscriptedMessageBase & {
   folder?: VoicemailFolderBase;
 };
 
@@ -1197,19 +1251,30 @@ export interface VoicemailMessageUpdate {
   folder_id: number;
 }
 
+export interface VoicemailMessageVoicemail {
+  /** The containing voicemail's type (either global or personal) */
+  accesstype?: "global" | "personal";
+  /** The containing voicemail's ID */
+  id?: number;
+  /** The containing voicemail's name */
+  name?: string;
+}
+
 export interface VoicemailMessages {
   /** List of voicemail messages */
   items?: (VoicemailMessage & {
-    voicemail?: {
-      /** The containing voicemail's type (either global or personal) */
-      accesstype?: "global" | "personal";
-      /** The containing voicemail's ID */
-      id?: number;
-      /** The containing voicemail's name */
-      name?: string;
-    };
+    voicemail?: VoicemailMessageVoicemail;
   })[];
   total?: number;
+}
+
+export type VoicemailTranscriptedMessageBase = VoicemailMessageBase & {
+  transcription?: VoicemailTranscription;
+};
+
+export interface VoicemailTranscription {
+  /** The transcription text */
+  text?: string;
 }
 
 export type VoicemailsDetailData = Voicemail;
@@ -1885,7 +1950,7 @@ export namespace Calls {
    */
   export namespace CallsDelete {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -1907,7 +1972,7 @@ export namespace Calls {
    */
   export namespace CallsDetail {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -1929,7 +1994,7 @@ export namespace Calls {
    */
   export namespace AnswerUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -1951,7 +2016,7 @@ export namespace Calls {
    */
   export namespace DtmfUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {
@@ -1976,7 +2041,7 @@ export namespace Calls {
    */
   export namespace HoldStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -1998,7 +2063,7 @@ export namespace Calls {
    */
   export namespace HoldStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2020,7 +2085,7 @@ export namespace Calls {
    */
   export namespace MuteStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2042,7 +2107,7 @@ export namespace Calls {
    */
   export namespace MuteStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2064,7 +2129,7 @@ export namespace Calls {
    */
   export namespace ParkUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2086,7 +2151,7 @@ export namespace Calls {
    */
   export namespace RecordPauseUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2108,7 +2173,7 @@ export namespace Calls {
    */
   export namespace RecordResumeUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2130,7 +2195,7 @@ export namespace Calls {
    */
   export namespace RecordStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2152,7 +2217,7 @@ export namespace Calls {
    */
   export namespace RecordStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2174,7 +2239,7 @@ export namespace Calls {
    */
   export namespace UserUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** UUID of the user */
       userUuid: string;
@@ -2555,7 +2620,7 @@ export namespace Switchboards {
    */
   export namespace CallsHeldUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** Unique identifier of the switchboard */
       switchboardUuid: string;
@@ -2579,7 +2644,7 @@ export namespace Switchboards {
    */
   export namespace CallsHeldAnswerUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** Unique identifier of the switchboard */
       switchboardUuid: string;
@@ -2628,7 +2693,7 @@ export namespace Switchboards {
    */
   export namespace CallsQueuedAnswerUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** Unique identifier of the switchboard */
       switchboardUuid: string;
@@ -2790,7 +2855,7 @@ export namespace Users {
    */
   export namespace MeCallsDelete {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2809,7 +2874,7 @@ export namespace Users {
    */
   export namespace MeCallsAnswerUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2828,7 +2893,7 @@ export namespace Users {
    */
   export namespace MeCallsDtmfUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {
@@ -2850,7 +2915,7 @@ export namespace Users {
    */
   export namespace MeCallsHoldStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2869,7 +2934,7 @@ export namespace Users {
    */
   export namespace MeCallsHoldStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2888,7 +2953,7 @@ export namespace Users {
    */
   export namespace MeCallsMuteStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2907,7 +2972,7 @@ export namespace Users {
    */
   export namespace MeCallsMuteStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2926,7 +2991,7 @@ export namespace Users {
    */
   export namespace MeCallsParkUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2948,7 +3013,7 @@ export namespace Users {
    */
   export namespace MeCallsRecordPauseUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2967,7 +3032,7 @@ export namespace Users {
    */
   export namespace MeCallsRecordResumeUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -2986,7 +3051,7 @@ export namespace Users {
    */
   export namespace MeCallsRecordStartUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -3005,7 +3070,7 @@ export namespace Users {
    */
   export namespace MeCallsRecordStopUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
     };
     export type RequestQuery = {};
@@ -3059,7 +3124,7 @@ export namespace Users {
    */
   export namespace MeConferencesAdhocParticipantsDelete {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** ID of the adhoc conference */
       conferenceId: string;
@@ -3080,7 +3145,7 @@ export namespace Users {
    */
   export namespace MeConferencesAdhocParticipantsUpdate {
     export type RequestParams = {
-      /** Call ID */
+      /** ID of the call */
       callId: string;
       /** ID of the adhoc conference */
       conferenceId: string;
@@ -3599,6 +3664,60 @@ export namespace Users {
 }
 
 export namespace Voicemails {
+  /**
+   * @description **Required ACL:** `calld.voicemails.messages.read`
+   * @tags voicemails
+   * @name MessagesList
+   * @summary List all voicemail messages in a tenant
+   * @request GET:/voicemails/messages
+   * @secure
+   */
+  export namespace MessagesList {
+    export type RequestParams = {};
+    export type RequestQuery = {
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
+      direction?: "asc" | "desc";
+      /**
+       * Filter messages with timestamp >= this value (ISO 8601 datetime)
+       * @format date-time
+       */
+      from?: string;
+      /** Maximum number of items to return in the list */
+      limit?: number;
+      /** Number of items to skip over in the list. Useful for pagination. */
+      offset?: number;
+      /** Name of the field to use for sorting the list of items returned. */
+      order?: string;
+      /**
+       * Include sub-tenants
+       * @default false
+       */
+      recurse?: boolean;
+      /** Filter messages by transcription availability */
+      transcribed?: boolean;
+      /**
+       * Filter messages with timestamp < this value (ISO 8601 datetime)
+       * @format date-time
+       */
+      until?: string;
+      /** Filter messages by user UUID (returns user's personal + global voicemails) */
+      user_uuid?: string;
+      /** Filter messages by voicemail ID */
+      voicemail_id?: number;
+      /**
+       * Filter messages by voicemail accesstype
+       * @default "all"
+       */
+      voicemail_type?: "all" | "personal" | "global";
+    };
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = MessagesListData;
+  }
+
   /**
    * @description **Required ACL:** `calld.voicemails.{voicemail_id}.read`
    * @tags voicemails

--- a/src/schemas/chatd.ts
+++ b/src/schemas/chatd.ts
@@ -28,6 +28,106 @@ export interface ConfigPatchItem {
   value?: object;
 }
 
+/** Connector */
+export interface Connector {
+  /**
+   * Whether the backend is ready to use for this tenant. For backends
+   * that require per-tenant credentials, this is true once wazo-auth has
+   * external credentials stored. Backends with no credential requirement
+   * (auth scope ``none``) are always reported as configured.
+   */
+  configured?: boolean;
+  /**
+   * Transport the backend uses to exchange messages with the provider.
+   * ``webhook`` requires configuring a provider-side callback to wazo;
+   * ``poll`` and ``listen`` need none.
+   */
+  mode?: "webhook" | "poll" | "listen";
+  /** The backend identifier */
+  name?: string;
+  /** Messaging types this backend can handle */
+  supported_types?: string[];
+}
+
+/** ConnectorAuthSchema */
+export interface ConnectorAuthSchema {
+  /** Fields required to collect the credentials. */
+  fields?: ConnectorAuthSchemaField[];
+  /**
+   * Where the credentials are stored. `none` means the backend needs
+   * no credentials; `tenant` means they live in wazo-auth tenant
+   * external config.
+   */
+  scope?: "none" | "tenant";
+}
+
+/** ConnectorAuthSchemaField */
+export interface ConnectorAuthSchemaField {
+  /** Allowed values; only emitted when `type` is `select`. */
+  choices?: string[];
+  default?: string;
+  label?: ConnectorLocalizedLabel[];
+  /** Machine-readable field name (used as the form key). */
+  name?: string;
+  required?: boolean;
+  type?: "string" | "secret" | "select" | "boolean" | "integer" | "url";
+}
+
+/** ConnectorIdentityBinding */
+export interface ConnectorIdentityBinding {
+  /** The UUID of the bound UserIdentity row */
+  identity_uuid?: string;
+  /** The UUID of the user the identity is bound to */
+  user_uuid?: string;
+}
+
+/** ConnectorIdentityItem */
+export interface ConnectorIdentityItem {
+  /** Wazo binding for this identity, or null when unbound */
+  binding?: ConnectorIdentityBinding;
+  /** Messaging capabilities of this identity (e.g. ["sms"], ["sms", "mms"]) */
+  capabilities?: string[];
+  /** The external identity value */
+  identity?: string;
+}
+
+/** ConnectorIdentityList */
+export interface ConnectorIdentityList {
+  items?: ConnectorIdentityItem[];
+  /** The number of results */
+  total?: number;
+}
+
+/** ConnectorList */
+export interface ConnectorList {
+  items?: Connector[];
+  /** The number of results */
+  total?: number;
+}
+
+/** ConnectorLocalizedLabel */
+export interface ConnectorLocalizedLabel {
+  /** Locale tag, e.g. `en_US`. */
+  language?: string;
+  value?: string;
+}
+
+export type ConnectorWebhookData = any;
+
+export type ConnectorWebhookError = APIError;
+
+export type ConnectorWebhookPayload = object;
+
+export type ConnectorWebhookWithHintData = any;
+
+export type ConnectorWebhookWithHintError = APIError;
+
+export type ConnectorWebhookWithHintPayload = object;
+
+export type CreateIdentityData = Identity;
+
+export type CreateIdentityError = APIError;
+
 export type CreateRoomData = Room;
 
 export type CreateRoomMessageData = Message;
@@ -52,6 +152,12 @@ export interface Error {
 
 export type GetConfigData = any;
 
+export type GetConnectorAuthSchemaData = ConnectorAuthSchema;
+
+export type GetConnectorAuthSchemaError = APIError;
+
+export type GetIdentityData = Identity;
+
 export type GetRoomData = Rooms;
 
 export interface GetRoomParams {
@@ -60,6 +166,77 @@ export interface GetRoomParams {
 }
 
 export type GetUserPresenceData = Presence;
+
+/** Identity */
+export type Identity = UserIdentity & {
+  /**
+   * Additional admin-managed metadata. Values must be
+   * scalars (string, integer, float, boolean, null) or
+   * lists of scalars. Keys ≤64 chars, individual values
+   * ≤1024 chars, total serialized size ≤4096 chars.
+   */
+  extra?: object;
+  /** The UUID of the tenant owning the identity */
+  tenant_uuid?: string;
+  /** The UUID of the user owning the identity */
+  user_uuid?: string;
+};
+
+/** IdentityCreateRequest */
+export interface IdentityCreateRequest {
+  /**
+   * The connector backend name
+   * @maxLength 64
+   */
+  backend: string;
+  /**
+   * Additional metadata. Values must be scalars (string,
+   * integer, float, boolean, null) or lists of scalars. Keys
+   * ≤64 chars, individual values ≤1024 chars, total serialized
+   * size ≤4096 chars.
+   */
+  extra?: object;
+  /**
+   * The external identity value
+   * @maxLength 256
+   */
+  identity: string;
+  /**
+   * The messaging type
+   * @maxLength 32
+   */
+  type: string;
+  /** The UUID of the user the identity is bound to */
+  user_uuid: string;
+}
+
+/** IdentityList */
+export interface IdentityList {
+  /** Count after applying filter parameters */
+  filtered?: number;
+  items?: Identity[];
+  /** Unfiltered count in the tenant scope */
+  total?: number;
+}
+
+/**
+ * IdentityUpdateRequest
+ * Partial update — every field is optional.
+ */
+export interface IdentityUpdateRequest {
+  /**
+   * Additional metadata. Values must be scalars (string,
+   * integer, float, boolean, null) or lists of scalars. Keys
+   * ≤64 chars, individual values ≤1024 chars, total serialized
+   * size ≤4096 chars.
+   */
+  extra?: object;
+  /**
+   * The external identity value
+   * @maxLength 256
+   */
+  identity?: string;
+}
 
 export interface Line {
   id?: number;
@@ -71,6 +248,43 @@ export interface Line {
     | "progressing"
     | "talking"
     | "unavailable";
+}
+
+export type ListConnectorIdentitiesData = ConnectorIdentityList;
+
+export type ListConnectorIdentitiesError = APIError;
+
+export type ListConnectorsData = ConnectorList;
+
+export type ListIdentitiesData = IdentityList;
+
+export interface ListIdentitiesParams {
+  /** Filter by exact backend name */
+  backend?: string;
+  /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
+  direction?: "asc" | "desc";
+  /** Filter by exact identity value */
+  identity?: string;
+  /** Maximum number of items to return in the list */
+  limit?: number;
+  /** Number of items to skip over in the list. Useful for pagination. */
+  offset?: number;
+  /** Name of the field to use for sorting the list of items returned. */
+  order?: "uuid" | "backend" | "type" | "identity";
+  /**
+   * Filter identities whose ``identity`` value contains this term,
+   * case-insensitive. Matching is a literal substring search; wildcard
+   * characters are escaped and not interpreted. Only the ``identity``
+   * column is searched.
+   */
+  search?: string;
+  /** Filter by exact messaging type */
+  type?: string;
+  /**
+   * Filter by user_uuid. Comma-separated list — a row matches if its
+   * user_uuid is any of the listed values (logical OR).
+   */
+  user_uuid?: string;
 }
 
 export type ListPresencesData = PresenceList;
@@ -124,6 +338,16 @@ export interface ListRoomsMessagesParams {
   search?: string;
 }
 
+export type ListUserMeIdentitiesData = UserIdentityList;
+
+export interface ListUserMeIdentitiesParams {
+  /**
+   * Filter identities by reachability for a specific room
+   * @format uuid
+   */
+  room_uuid?: string;
+}
+
 export interface Message {
   /** Alias/nickname of the sender */
   alias?: string;
@@ -131,6 +355,13 @@ export interface Message {
   content?: string;
   /** The date of the message's creation */
   created_at?: string;
+  /**
+   * Delivery metadata for the message. Always present on the response.
+   * Internal messages report `type=internal`, `backend=null`, and an empty
+   * `recipients` array. External messages carry the channel info and one
+   * recipient per outbound leg.
+   */
+  delivery?: MessageDelivery;
   room?: RoomRelationBase;
   /** tenant uuid of the sender */
   tenant_uuid?: string;
@@ -140,6 +371,33 @@ export interface Message {
   uuid?: string;
   /** wazo uuid of the sender */
   wazo_uuid?: string;
+}
+
+/**
+ * Delivery metadata for the message. Always present on the response.
+ * Internal messages report `type=internal`, `backend=null`, and an empty
+ * `recipients` array. External messages carry the channel info and one
+ * recipient per outbound leg.
+ */
+export interface MessageDelivery {
+  /** The connector backend name (e.g. 'twilio'). Null for internal messages. */
+  backend?: string;
+  /** Per-recipient delivery state. Empty for internal messages. */
+  recipients?: MessageRecipient[];
+  /** The messaging type (e.g. 'internal', 'sms') */
+  type?: string;
+}
+
+export interface MessageRecipient {
+  /** The recipient's external address (e.g. phone number) */
+  identity?: string;
+  /**
+   * Current delivery state for this recipient. One of: pending,
+   * retrying, accepted, sent, delivered, failed, dead_letter.
+   */
+  status?: string;
+  /** Timestamp of the latest status transition for this recipient */
+  updated_at?: string;
 }
 
 /** UserItems */
@@ -212,6 +470,8 @@ export interface RoomRelationBase {
 }
 
 export interface RoomUser {
+  /** The external identity of this participant (e.g. a phone number for SMS). When set, the participant is reachable via the matching connector backend. */
+  identity?: string;
   /** The tenant of the user_uuid. Default to the same tenant as the token owner */
   tenant_uuid?: string;
   uuid: string;
@@ -240,15 +500,52 @@ export enum StatusValue {
   Ok = "ok",
 }
 
+export type UpdateIdentityData = Identity;
+
+export type UpdateIdentityError = APIError;
+
 export type UpdateTeamsPresenceData = ResourceUpdated;
 
 export type UpdateTeamsPresenceError = NotFoundError;
 
+/** UserIdentity */
+export interface UserIdentity {
+  /**
+   * The connector backend name
+   * @maxLength 64
+   */
+  backend?: string;
+  /**
+   * The external identity value
+   * @maxLength 256
+   */
+  identity?: string;
+  /**
+   * The messaging type
+   * @maxLength 32
+   */
+  type?: string;
+  /** The UUID of the identity */
+  uuid?: string;
+}
+
+/** UserIdentityList */
+export interface UserIdentityList {
+  items?: UserIdentity[];
+  /** The number of results */
+  total?: number;
+}
+
 export interface UserMessagePOST {
   /** Alias/nickname of the sender */
-  alias: string;
+  alias?: string;
   /** The content of the message */
   content: string;
+  /**
+   * The UUID of the sender's identity to use for outbound delivery. Required when the room contains external participants.
+   * @format uuid
+   */
+  sender_identity_uuid?: string;
 }
 
 export namespace Config {
@@ -285,6 +582,248 @@ export namespace Config {
   }
 }
 
+export namespace Connectors {
+  /**
+   * @description **Required ACL:** `chatd.connectors.read` Returns supported types and tenant-configured state for each registered backend.
+   * @tags connectors
+   * @name ListConnectors
+   * @summary List capability metadata for every registered backend
+   * @request GET:/connectors
+   * @secure
+   */
+  export namespace ListConnectors {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = ListConnectorsData;
+  }
+
+  /**
+   * @description Dispatches an incoming webhook to the matching connector backend. **Body size**: capped at 4 MB at the nginx layer. Bodies above the cap are rejected with HTTP 413 before reaching chatd.
+   * @tags connectors
+   * @name ConnectorWebhook
+   * @summary Receive incoming webhook from connector
+   * @request POST:/connectors/incoming
+   */
+  export namespace ConnectorWebhook {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = ConnectorWebhookPayload;
+    export type RequestHeaders = {};
+    export type ResponseBody = ConnectorWebhookData;
+  }
+
+  /**
+   * @description Dispatches an incoming webhook, trying the specified backend first.
+   * @tags connectors
+   * @name ConnectorWebhookWithHint
+   * @summary Receive incoming webhook with backend hint
+   * @request POST:/connectors/incoming/{backend}
+   */
+  export namespace ConnectorWebhookWithHint {
+    export type RequestParams = {
+      /** Backend name hint for faster dispatch */
+      backend: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = ConnectorWebhookWithHintPayload;
+    export type RequestHeaders = {};
+    export type ResponseBody = ConnectorWebhookWithHintData;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.connectors.{backend}.auth-schema.read` Returns the connector's declared credential fields and where the credentials live (`scope`). The body is class-level metadata — identical across tenants.
+   * @tags connectors
+   * @name GetConnectorAuthSchema
+   * @summary Get the credential schema declared by the backend
+   * @request GET:/connectors/{backend}/auth-schema
+   * @secure
+   */
+  export namespace GetConnectorAuthSchema {
+    export type RequestParams = {
+      /** The backend name */
+      backend: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** Quoted ETag of a previously fetched body */
+      "If-None-Match"?: string;
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = GetConnectorAuthSchemaData;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.connectors.{backend}.identities.read` Each item carries the backend-reported identity and its binding to a Wazo user (``null`` when unbound).
+   * @tags connectors
+   * @name ListConnectorIdentities
+   * @summary List identities the backend reports this tenant owns
+   * @request GET:/connectors/{backend}/identities
+   * @secure
+   */
+  export namespace ListConnectorIdentities {
+    export type RequestParams = {
+      /** The backend name */
+      backend: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = ListConnectorIdentitiesData;
+  }
+}
+
+export namespace Identities {
+  /**
+   * @description **Required ACL:** `chatd.identities.read` Returns every identity bound to a user in the calling tenant. The `Wazo-Tenant` header scopes the result; each item includes its owner (`user_uuid`) and `tenant_uuid`.
+   * @tags identities
+   * @name ListIdentities
+   * @summary List all identities visible to the tenant
+   * @request GET:/identities
+   * @secure
+   */
+  export namespace ListIdentities {
+    export type RequestParams = {};
+    export type RequestQuery = {
+      /** Filter by exact backend name */
+      backend?: string;
+      /** Sort list of items in 'asc' (ascending) or 'desc' (descending) order */
+      direction?: "asc" | "desc";
+      /** Filter by exact identity value */
+      identity?: string;
+      /** Maximum number of items to return in the list */
+      limit?: number;
+      /** Number of items to skip over in the list. Useful for pagination. */
+      offset?: number;
+      /** Name of the field to use for sorting the list of items returned. */
+      order?: "uuid" | "backend" | "type" | "identity";
+      /**
+       * Filter identities whose ``identity`` value contains this term,
+       * case-insensitive. Matching is a literal substring search; wildcard
+       * characters are escaped and not interpreted. Only the ``identity``
+       * column is searched.
+       */
+      search?: string;
+      /** Filter by exact messaging type */
+      type?: string;
+      /**
+       * Filter by user_uuid. Comma-separated list — a row matches if its
+       * user_uuid is any of the listed values (logical OR).
+       */
+      user_uuid?: string;
+    };
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = ListIdentitiesData;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.identities.create` Creates an external identity for the user named in the body on a configured backend.
+   * @tags identities
+   * @name CreateIdentity
+   * @summary Create an identity
+   * @request POST:/identities
+   * @secure
+   */
+  export namespace CreateIdentity {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = IdentityCreateRequest;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = CreateIdentityData;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.identities.{identity_uuid}.delete`
+   * @tags identities
+   * @name DeleteIdentity
+   * @summary Delete an identity
+   * @request DELETE:/identities/{identity_uuid}
+   * @secure
+   */
+  export namespace DeleteIdentity {
+    export type RequestParams = {
+      /**
+       * The UUID of the identity
+       * @format uuid
+       */
+      identityUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.identities.{identity_uuid}.read`
+   * @tags identities
+   * @name GetIdentity
+   * @summary Get an identity by UUID
+   * @request GET:/identities/{identity_uuid}
+   * @secure
+   */
+  export namespace GetIdentity {
+    export type RequestParams = {
+      /**
+       * The UUID of the identity
+       * @format uuid
+       */
+      identityUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = GetIdentityData;
+  }
+
+  /**
+   * @description **Required ACL:** `chatd.identities.{identity_uuid}.update` Updates one or more mutable fields.
+   * @tags identities
+   * @name UpdateIdentity
+   * @summary Update an identity (partial)
+   * @request PUT:/identities/{identity_uuid}
+   * @secure
+   */
+  export namespace UpdateIdentity {
+    export type RequestParams = {
+      /**
+       * The UUID of the identity
+       * @format uuid
+       */
+      identityUuid: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = IdentityUpdateRequest;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource. */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = UpdateIdentityData;
+  }
+}
+
 export namespace Status {
   /**
    * @description **Required ACL:** `chatd.status.read`
@@ -304,6 +843,28 @@ export namespace Status {
 }
 
 export namespace Users {
+  /**
+   * @description **Required ACL:** `chatd.users.me.identities.read` Returns all identities of the authenticated user. When a `room_uuid` is provided, returns only identities usable to reach the other participants of that room.
+   * @tags identities
+   * @name ListUserMeIdentities
+   * @summary List identities for the authenticated user
+   * @request GET:/users/me/identities
+   * @secure
+   */
+  export namespace ListUserMeIdentities {
+    export type RequestParams = {};
+    export type RequestQuery = {
+      /**
+       * Filter identities by reachability for a specific room
+       * @format uuid
+       */
+      room_uuid?: string;
+    };
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ListUserMeIdentitiesData;
+  }
+
   /**
    * @description **Required ACL:** `chatd.users.me.rooms.read`
    * @tags rooms

--- a/src/schemas/confd.ts
+++ b/src/schemas/confd.ts
@@ -253,6 +253,11 @@
     is_webrtc?: boolean,
   /** User language (e.g. "en_US") */
     language?: "de_DE" | "en_US" | "es_ES" | "fr_FR" | "fr_CA" | "it_IT" | "nl_NL",
+  /**
+   * Enable PSTN fallback when push notification is not answered in time
+   * @default false
+   */
+    mobile_fallback_enabled?: boolean,
   /** Phone number for the user’s mobile device */
     mobile_phone_number?: string,
   /** Name of the MOH category to use for music on hold */
@@ -1901,6 +1906,8 @@
     export type GetUsersSubscriptionsData = UserSubscriptionItems
 
     export type GetVoicemailData = Voicemail
+
+    export type GetVoicemailTranscriptionConfigData = VoicemailTranscriptionConfig
 
     export type GetWizardDiscoverData = WizardDiscover
 
@@ -4706,6 +4713,8 @@
 
     export type UpdateUsersCsvPayload = string
 
+    export type UpdateVoicemailTranscriptionConfigData = any
+
   /** User */
   export type User = (BaseUser & UserRelationAgent & UserRelationFallbacks & UserRelationForwards & UserRelationGroups & UserRelationIncalls & UserRelationLines & UserRelationServices & UserRelationSwitchboards & UserRelationVoicemail & UserRelationQueues & UserRelationCallPickupTargets)
 
@@ -4741,7 +4750,9 @@
 
   /** UserCallerID */
   export interface UserCallerID {
-  /** Caller ID number. Only valid for `main` `associated` type */
+  /** Caller ID name. Only valid for `main` and `shared` types */
+    caller_id_name?: string,
+  /** Caller ID number. Only valid for `main` `associated` and `shared` types */
     number?: string,
   /**
    * Caller ID type.
@@ -4972,6 +4983,11 @@
   /** User lastname */
     lastname?: string,
     lines?: (UserPostRelationLine)[],
+  /**
+   * Enable PSTN fallback when push notification is not answered in time
+   * @default false
+   */
+    mobile_fallback_enabled?: boolean,
   /** Phone number for the user’s mobile device */
     mobile_phone_number?: string,
   /** Name of the MOH category to use for music on hold */
@@ -5223,6 +5239,15 @@
 
     export interface VoicemailRelationUsers {
     users?: (UserRelationBase)[],
+}
+
+    export interface VoicemailTranscriptionConfig {
+  /**
+   * Enable or disable automatic transcription of voicemails for this tenant.
+   * @default false
+   * @example true
+   */
+    enabled: boolean,
 }
 
   /** VoicemailZoneMessage */
@@ -5676,7 +5701,7 @@ export namespace UpdateSkill {
 */
 export namespace DeleteAgent {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
 
 };
@@ -5700,7 +5725,7 @@ export namespace DeleteAgent {
 */
 export namespace GetAgent {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
 
 };
@@ -5724,7 +5749,7 @@ export namespace GetAgent {
 */
 export namespace UpdateAgent {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
 
 };
@@ -5748,7 +5773,7 @@ export namespace UpdateAgent {
 */
 export namespace DissociateAgentSkill {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
   /** Skill's ID */
     skillId: number,
@@ -5774,7 +5799,7 @@ export namespace DissociateAgentSkill {
 */
 export namespace AssociateAgentSkill {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
   /** Skill's ID */
     skillId: number,
@@ -6391,7 +6416,7 @@ export namespace UpdateAsteriskSccpGeneral {
         
 /**
  * @description **Required ACL:** `confd.asterisk.voicemail.general.read`
- * @tags asterisk
+ * @tags asterisk, voicemails
  * @name ListAsteriskVoicemailGeneral
  * @summary List Voicemail general options
  * @request GET:/asterisk/voicemail/general
@@ -6407,7 +6432,7 @@ export namespace ListAsteriskVoicemailGeneral {
         
 /**
  * @description **Required ACL:** `confd.asterisk.voicemail.general.update` **WARNING** This endpoint restore to default value or delete all fields that are not defined.
- * @tags asterisk
+ * @tags asterisk, voicemails
  * @name UpdateAsteriskVoicemailGeneral
  * @summary Update Voicemail general option
  * @request PUT:/asterisk/voicemail/general
@@ -11815,7 +11840,7 @@ export namespace UpdateSkillRule {
 */
 export namespace DeleteQueue {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11839,7 +11864,7 @@ export namespace DeleteQueue {
 */
 export namespace GetQueue {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11863,7 +11888,7 @@ export namespace GetQueue {
 */
 export namespace UpdateQueue {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11888,7 +11913,7 @@ export namespace UpdateQueue {
 export namespace DissociateQueueExtension {
   export type RequestParams = {
     extensionId: number,
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11913,7 +11938,7 @@ export namespace DissociateQueueExtension {
 export namespace AssociateQueueExtension {
   export type RequestParams = {
     extensionId: number,
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11937,7 +11962,7 @@ export namespace AssociateQueueExtension {
 */
 export namespace GetQueueFallback {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11961,7 +11986,7 @@ export namespace GetQueueFallback {
 */
 export namespace UpdateQueueFallback {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -11985,9 +12010,9 @@ export namespace UpdateQueueFallback {
 */
 export namespace DissociateAgentQueue {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -12011,9 +12036,9 @@ export namespace DissociateAgentQueue {
 */
 export namespace UpdateAgentQueueAssociation {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
 
 };
@@ -12037,7 +12062,7 @@ export namespace UpdateAgentQueueAssociation {
 */
 export namespace DissociateUserQueue {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
   /** the user's ID or UUID */
     userId: string,
@@ -12063,7 +12088,7 @@ export namespace DissociateUserQueue {
 */
 export namespace UpdateUserQueueAssociation {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
   /** the user's ID or UUID */
     userId: string,
@@ -12089,7 +12114,7 @@ export namespace UpdateUserQueueAssociation {
 */
 export namespace DissociateQueueSchedule {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
   /** Schedule's ID */
     scheduleId: number,
@@ -12115,7 +12140,7 @@ export namespace DissociateQueueSchedule {
 */
 export namespace AssociateQueueSchedule {
   export type RequestParams = {
-  /** queue's ID */
+  /** Queue’s ID */
     queueId: number,
   /** Schedule's ID */
     scheduleId: number,
@@ -14156,7 +14181,7 @@ export namespace DissociateUserAgent {
 */
 export namespace AssociateUserAgent {
   export type RequestParams = {
-  /** Agent’s ID */
+  /** Agent's ID */
     agentId: number,
   /** the user's ID or UUID */
     userId: string,
@@ -15257,6 +15282,46 @@ export namespace CreateVoicemail {
   export type RequestBody = Voicemail;
   export type RequestHeaders = {};
   export type ResponseBody = CreateVoicemailData;
+}
+        
+/**
+ * @description Returns the current transcription settings, including whether automatic transcription is enabled for the tenant's voicemails. **required_acl**: `confd.voicemails.transcription.read`
+ * @tags voicemails, transcription
+ * @name GetVoicemailTranscriptionConfig
+ * @summary Retrieve the voicemail transcription configuration for the tenant
+ * @request GET:/voicemails/transcription
+ * @secure
+*/
+export namespace GetVoicemailTranscriptionConfig {
+  export type RequestParams = {};
+  export type RequestQuery = {};
+  export type RequestBody = never;
+  export type RequestHeaders = {
+  /** The tenant's UUID, defining the ownership of a given resource. */
+    "Wazo-Tenant"?: string,
+
+};
+  export type ResponseBody = GetVoicemailTranscriptionConfigData;
+}
+        
+/**
+ * @description **required_acl**: `confd.voicemails.transcription.update`
+ * @tags voicemails, transcription
+ * @name UpdateVoicemailTranscriptionConfig
+ * @summary Update the voicemail transcription configuration for the tenant.
+ * @request PUT:/voicemails/transcription
+ * @secure
+*/
+export namespace UpdateVoicemailTranscriptionConfig {
+  export type RequestParams = {};
+  export type RequestQuery = {};
+  export type RequestBody = VoicemailTranscriptionConfig;
+  export type RequestHeaders = {
+  /** The tenant's UUID, defining the ownership of a given resource. */
+    "Wazo-Tenant"?: string,
+
+};
+  export type ResponseBody = UpdateVoicemailTranscriptionConfigData;
 }
         
 /**

--- a/src/schemas/confdPortal.ts
+++ b/src/schemas/confdPortal.ts
@@ -274,7 +274,7 @@ export interface ListCustomersParams {
   direction?: "asc" | "desc";
   /** The limit defines the number of individual objects that are returned */
   limit?: number;
-  /** Comma-separated list of names to filter resellers by */
+  /** Comma-separated list of names to filter customers by */
   name?: string;
   /**
    * The offset defines the offsets the start by the number specified
@@ -290,7 +290,7 @@ export interface ListCustomersParams {
   recurse?: boolean;
   /** Search term used to filter the result */
   search?: string;
-  /** Comma-separated list of UUIDs to filter resellers by */
+  /** Comma-separated list of UUIDs to filter customers by */
   uuid?: string;
 }
 
@@ -315,7 +315,7 @@ export interface ListLocationsParams {
   instance_uuid?: string;
   /** The limit defines the number of individual objects that are returned */
   limit?: number;
-  /** Comma-separated list of names to filter resellers by */
+  /** Comma-separated list of names to filter customers by */
   name?: string;
   /**
    * The offset defines the offsets the start by the number specified
@@ -331,7 +331,7 @@ export interface ListLocationsParams {
   recurse?: boolean;
   /** Search term used to filter the result */
   search?: string;
-  /** Comma-separated list of UUIDs to filter resellers by */
+  /** Comma-separated list of UUIDs to filter customers by */
   uuid?: string;
   /** Instance tenant UUID to filter locations by */
   wazo_tenant_uuid?: string;
@@ -344,7 +344,7 @@ export interface ListResellersParams {
   direction?: "asc" | "desc";
   /** The limit defines the number of individual objects that are returned */
   limit?: number;
-  /** Comma-separated list of names to filter resellers by */
+  /** Comma-separated list of names to filter customers by */
   name?: string;
   /**
    * The offset defines the offsets the start by the number specified
@@ -357,7 +357,7 @@ export interface ListResellersParams {
   parent_uuid?: string;
   /** Search term used to filter the result */
   search?: string;
-  /** Comma-separated list of UUIDs to filter resellers by */
+  /** Comma-separated list of UUIDs to filter customers by */
   uuid?: string;
 }
 
@@ -610,7 +610,7 @@ export namespace Accounts {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = ListAccountsData;
   }
@@ -632,7 +632,7 @@ export namespace Accounts {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = GetTenantsSummaryAccountData;
   }
@@ -674,7 +674,7 @@ export namespace Customers {
       direction?: "asc" | "desc";
       /** The limit defines the number of individual objects that are returned */
       limit?: number;
-      /** Comma-separated list of names to filter resellers by */
+      /** Comma-separated list of names to filter customers by */
       name?: string;
       /**
        * The offset defines the offsets the start by the number specified
@@ -690,7 +690,7 @@ export namespace Customers {
       recurse?: boolean;
       /** Search term used to filter the result */
       search?: string;
-      /** Comma-separated list of UUIDs to filter resellers by */
+      /** Comma-separated list of UUIDs to filter customers by */
       uuid?: string;
     };
     export type RequestBody = never;
@@ -876,7 +876,7 @@ export namespace Instances {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = ListInstancesData;
   }
@@ -902,7 +902,7 @@ export namespace Locations {
       instance_uuid?: string;
       /** The limit defines the number of individual objects that are returned */
       limit?: number;
-      /** Comma-separated list of names to filter resellers by */
+      /** Comma-separated list of names to filter customers by */
       name?: string;
       /**
        * The offset defines the offsets the start by the number specified
@@ -918,7 +918,7 @@ export namespace Locations {
       recurse?: boolean;
       /** Search term used to filter the result */
       search?: string;
-      /** Comma-separated list of UUIDs to filter resellers by */
+      /** Comma-separated list of UUIDs to filter customers by */
       uuid?: string;
       /** Instance tenant UUID to filter locations by */
       wazo_tenant_uuid?: string;
@@ -1053,7 +1053,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = GetPluginsData;
   }
@@ -1075,7 +1075,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = any;
   }
@@ -1103,7 +1103,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = any;
   }
@@ -1131,7 +1131,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = GetPluginData;
   }
@@ -1159,7 +1159,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = any;
   }
@@ -1202,7 +1202,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsCustomersListData;
   }
@@ -1230,7 +1230,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsCustomersCreateData;
   }
@@ -1273,7 +1273,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsLocationsListData;
   }
@@ -1301,7 +1301,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsLocationsCreateData;
   }
@@ -1344,7 +1344,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsResellersListData;
   }
@@ -1372,7 +1372,7 @@ export namespace Plugins {
        * The tenant's UUID, defining the ownership of a given resource.
        * @format uuid
        */
-      "Wazo-Tenant": string;
+      "Wazo-Tenant"?: string;
     };
     export type ResponseBody = InstallsResellersCreateData;
   }
@@ -1394,7 +1394,7 @@ export namespace Resellers {
       direction?: "asc" | "desc";
       /** The limit defines the number of individual objects that are returned */
       limit?: number;
-      /** Comma-separated list of names to filter resellers by */
+      /** Comma-separated list of names to filter customers by */
       name?: string;
       /**
        * The offset defines the offsets the start by the number specified
@@ -1407,7 +1407,7 @@ export namespace Resellers {
       parent_uuid?: string;
       /** Search term used to filter the result */
       search?: string;
-      /** Comma-separated list of UUIDs to filter resellers by */
+      /** Comma-separated list of UUIDs to filter customers by */
       uuid?: string;
     };
     export type RequestBody = never;

--- a/src/schemas/dird.ts
+++ b/src/schemas/dird.ts
@@ -315,7 +315,7 @@ export interface ExternalServiceConfig {
   timeout?: number;
   /**
    * If the HTTPs certificates should be verified and the path of the certificate if a custom certificate is used.
-   * @default true
+   * @default "true"
    */
   verify_certificate?: string;
 }
@@ -1289,18 +1289,15 @@ export type UpdatePhonebookSourceError = LegacyError;
 export type UpdateWazoSourceError = LegacyError;
 
 /** Auth */
-export type WazoAuthConfig = ExternalServiceConfig & {
-  /** The path the the file containing the credentials */
-  key_file?: string;
-  /** The password to use when not using a key_file */
-  password?: string;
-  /** @default 9497 */
-  port?: number;
-  /** The username to use when not using a key_file */
-  username?: string;
-  /** @default "0.1" */
-  version?: string;
-};
+export type WazoAuthConfig = ExternalServiceConfig &
+  WazoAuthConfigNoAuth & {
+    /** The path the the file containing the credentials */
+    key_file?: string;
+    /** The password to use when not using a key_file */
+    password?: string;
+    /** The username to use when not using a key_file */
+    username?: string;
+  };
 
 /** Auth */
 export type WazoAuthConfigNoAuth = ExternalServiceConfig & {

--- a/src/schemas/provd.ts
+++ b/src/schemas/provd.ts
@@ -20,7 +20,7 @@ export interface ComponentWithStatus {
 
 /**
  * A complete configuration
- * @example {"deletable":true,"id":"abcdef123456890","parent_ids":["base"],"raw_config":{"sip_lines":{"1":{"auth_username":"100","display_name":"Foo","password":"100","username":"100"}}}}
+ * @example {"id":"abcdef123456890","deletable":true,"parent_ids":["base"],"raw_config":{"sip_lines":{"1":{"auth_username":"100","display_name":"Foo","password":"100","username":"100"}}}}
  */
 export interface Config {
   deletable?: boolean;
@@ -377,175 +377,6 @@ export type SynchronizeCreateData = any;
 
 export type SynchronizeDetailData = OperationInProgressObject;
 
-export namespace CfgMgr {
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.read` The configuration manager resource represents the entry point to the wazo-provd configuration REST API
-   * @tags configs
-   * @name CfgMgrList
-   * @summary Get the Config Manager resource
-   * @request GET:/cfg_mgr
-   * @secure
-   */
-  export namespace CfgMgrList {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = CfgMgrListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.autocreate.create` Create a new config based on the config that has the autocreate role
-   * @tags configs
-   * @name AutocreateCreate
-   * @summary Create an autocreate configuration
-   * @request POST:/cfg_mgr/autocreate
-   * @secure
-   */
-  export namespace AutocreateCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = EmptyObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = IdObject;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.read`
-   * @tags configs
-   * @name ConfigsList
-   * @summary List and find configurations
-   * @request GET:/cfg_mgr/configs
-   * @secure
-   */
-  export namespace ConfigsList {
-    export type RequestParams = {};
-    export type RequestQuery = {
-      /**
-       * A list of fields, separated by comma.
-       *
-       * Example: `mac,ip`
-       */
-      fields?: string;
-      /**
-       * A selector, encoded in JSON, describing which entries should be returned. All entries are returned if not specified.
-       *
-       * Example: `{"ip":"10.34.1.110"}`
-       */
-      q?: string;
-      /**
-       * An integer specifing the number of entries to skip.
-       *
-       * Example: 10
-       */
-      skip?: number;
-      /**
-       * The key on which to sort the results.
-       *
-       * Example: `id`
-       */
-      sort?: string;
-      /** The order of sort */
-      sort_ord?: "ASC" | "DESC";
-    };
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = ConfigsObject;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.create`
-   * @tags configs
-   * @name ConfigsCreate
-   * @summary Create a configuration
-   * @request POST:/cfg_mgr/configs
-   * @secure
-   */
-  export namespace ConfigsCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = ConfigObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = IdObject;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.delete`
-   * @tags configs
-   * @name ConfigsDelete
-   * @summary Delete a configuration
-   * @request DELETE:/cfg_mgr/configs/{config_id}
-   * @secure
-   */
-  export namespace ConfigsDelete {
-    export type RequestParams = {
-      /** Configuration ID */
-      configId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.read`
-   * @tags configs
-   * @name ConfigsDetail
-   * @summary Get a configuration
-   * @request GET:/cfg_mgr/configs/{config_id}
-   * @secure
-   */
-  export namespace ConfigsDetail {
-    export type RequestParams = {
-      /** Configuration ID */
-      configId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = ConfigObject;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.update`
-   * @tags configs
-   * @name ConfigsUpdate
-   * @summary Update a configuration
-   * @request PUT:/cfg_mgr/configs/{config_id}
-   * @secure
-   */
-  export namespace ConfigsUpdate {
-    export type RequestParams = {
-      /** Configuration ID */
-      configId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = ConfigObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.raw.read`
-   * @tags configs
-   * @name ConfigsRawList
-   * @summary Get a raw configuration
-   * @request GET:/cfg_mgr/configs/{config_id}/raw
-   * @secure
-   */
-  export namespace ConfigsRawList {
-    export type RequestParams = {
-      /** Configuration ID */
-      configId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = ConfigsRawListData;
-  }
-}
-
 export namespace Configure {
   /**
    * @description **Required ACL:** `provd.configure.read`
@@ -561,121 +392,6 @@ export namespace Configure {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = ConfigureListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.nat.update`
-   * @tags provd
-   * @name PutConfigure
-   * @summary Update the configuration's NAT
-   * @request PUT:/configure/NAT
-   * @secure
-   */
-  export namespace PutConfigure {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = Nat;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.ftp_proxy.update`
-   * @tags provd
-   * @name FtpProxyUpdate
-   * @summary Update the configuration's ftp_proxy
-   * @request PUT:/configure/ftp_proxy
-   * @secure
-   */
-  export namespace FtpProxyUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = FtpProxy;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.http_proxy.update`
-   * @tags provd
-   * @name HttpProxyUpdate
-   * @summary Update the configuration's http_proxy
-   * @request PUT:/configure/http_proxy
-   * @secure
-   */
-  export namespace HttpProxyUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = HttpProxy;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.https_proxy.update`
-   * @tags provd
-   * @name HttpsProxyUpdate
-   * @summary Update the configuration's https_proxy
-   * @request PUT:/configure/https_proxy
-   * @secure
-   */
-  export namespace HttpsProxyUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = HttpsProxy;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.locale.update`
-   * @tags provd
-   * @name LocaleUpdate
-   * @summary Update the configuration's locale
-   * @request PUT:/configure/locale
-   * @secure
-   */
-  export namespace LocaleUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = Locale;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.plugin_server.update`
-   * @tags provd
-   * @name PluginServerUpdate
-   * @summary Update the configuration's plugin_server
-   * @request PUT:/configure/plugin_server
-   * @secure
-   */
-  export namespace PluginServerUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = PluginServer;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.configure.{tenant_uuid}.provisioning_key.update`
-   * @tags provd
-   * @name ProvisioningKeyUpdate
-   * @summary Update the tenant provisioning key
-   * @request PUT:/configure/provisioning_key
-   * @secure
-   */
-  export namespace ProvisioningKeyUpdate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = ProvisioningKey;
-    export type RequestHeaders = {
-      /** The tenant's UUID, defining the ownership of a given resource */
-      "Wazo-Tenant"?: string;
-    };
-    export type ResponseBody = any;
   }
 
   /**
@@ -716,6 +432,121 @@ export namespace Configure {
     export type RequestQuery = {};
     export type RequestBody = Param;
     export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.plugin_server.update`
+   * @tags provd
+   * @name PluginServerUpdate
+   * @summary Update the configuration's plugin_server
+   * @request PUT:/configure/plugin_server
+   * @secure
+   */
+  export namespace PluginServerUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = PluginServer;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.http_proxy.update`
+   * @tags provd
+   * @name HttpProxyUpdate
+   * @summary Update the configuration's http_proxy
+   * @request PUT:/configure/http_proxy
+   * @secure
+   */
+  export namespace HttpProxyUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = HttpProxy;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.https_proxy.update`
+   * @tags provd
+   * @name HttpsProxyUpdate
+   * @summary Update the configuration's https_proxy
+   * @request PUT:/configure/https_proxy
+   * @secure
+   */
+  export namespace HttpsProxyUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = HttpsProxy;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.ftp_proxy.update`
+   * @tags provd
+   * @name FtpProxyUpdate
+   * @summary Update the configuration's ftp_proxy
+   * @request PUT:/configure/ftp_proxy
+   * @secure
+   */
+  export namespace FtpProxyUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = FtpProxy;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.locale.update`
+   * @tags provd
+   * @name LocaleUpdate
+   * @summary Update the configuration's locale
+   * @request PUT:/configure/locale
+   * @secure
+   */
+  export namespace LocaleUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = Locale;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.nat.update`
+   * @tags provd
+   * @name PutConfigure
+   * @summary Update the configuration's NAT
+   * @request PUT:/configure/NAT
+   * @secure
+   */
+  export namespace PutConfigure {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = Nat;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.configure.{tenant_uuid}.provisioning_key.update`
+   * @tags provd
+   * @name ProvisioningKeyUpdate
+   * @summary Update the tenant provisioning key
+   * @request PUT:/configure/provisioning_key
+   * @secure
+   */
+  export namespace ProvisioningKeyUpdate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = ProvisioningKey;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource */
+      "Wazo-Tenant"?: string;
+    };
     export type ResponseBody = any;
   }
 }
@@ -808,28 +639,6 @@ export namespace DevMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.dev_mgr.devices.{device_id}.delete`
-   * @tags devices
-   * @name DevicesDelete
-   * @summary Delete a device
-   * @request DELETE:/dev_mgr/devices/{device_id}
-   * @secure
-   */
-  export namespace DevicesDelete {
-    export type RequestParams = {
-      /** Device ID */
-      deviceId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {
-      /** The tenant's UUID, defining the ownership of a given resource */
-      "Wazo-Tenant"?: string;
-    };
-    export type ResponseBody = any;
-  }
-
-  /**
    * @description **Required ACL:** `provd.dev_mgr.devices.{device_id}.read` Get a device using its ID
    * @tags devices
    * @name DevicesDetail
@@ -874,36 +683,20 @@ export namespace DevMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.dev_mgr.dhcpinfo.create` The provisioning server either creates a new device or changes the information of the device with the same MAC address
+   * @description **Required ACL:** `provd.dev_mgr.devices.{device_id}.delete`
    * @tags devices
-   * @name DhcpinfoCreate
-   * @summary Push DHCP request information
-   * @request POST:/dev_mgr/dhcpinfo
+   * @name DevicesDelete
+   * @summary Delete a device
+   * @request DELETE:/dev_mgr/devices/{device_id}
    * @secure
    */
-  export namespace DhcpinfoCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = DHCPInfoObject;
-    export type RequestHeaders = {
-      /** The tenant's UUID, defining the ownership of a given resource */
-      "Wazo-Tenant"?: string;
+  export namespace DevicesDelete {
+    export type RequestParams = {
+      /** Device ID */
+      deviceId: string;
     };
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.dev_mgr.reconfigure.create` Regenerate the configuration file for the specified device
-   * @tags devices
-   * @name ReconfigureCreate
-   * @summary Reconfigure a device
-   * @request POST:/dev_mgr/reconfigure
-   * @secure
-   */
-  export namespace ReconfigureCreate {
-    export type RequestParams = {};
     export type RequestQuery = {};
-    export type RequestBody = IdObject;
+    export type RequestBody = never;
     export type RequestHeaders = {
       /** The tenant's UUID, defining the ownership of a given resource */
       "Wazo-Tenant"?: string;
@@ -931,6 +724,25 @@ export namespace DevMgr {
   }
 
   /**
+   * @description **Required ACL:** `provd.operation.read`
+   * @tags devices
+   * @name SynchronizeDetail
+   * @summary Get the status of a synchronize Operation In Progress
+   * @request GET:/dev_mgr/synchronize/{operation_id}
+   * @secure
+   */
+  export namespace SynchronizeDetail {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = SynchronizeDetailData;
+  }
+
+  /**
    * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
    * @tags devices
    * @name SynchronizeDelete
@@ -950,22 +762,210 @@ export namespace DevMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.operation.read`
+   * @description **Required ACL:** `provd.dev_mgr.reconfigure.create` Regenerate the configuration file for the specified device
    * @tags devices
-   * @name SynchronizeDetail
-   * @summary Get the status of a synchronize Operation In Progress
-   * @request GET:/dev_mgr/synchronize/{operation_id}
+   * @name ReconfigureCreate
+   * @summary Reconfigure a device
+   * @request POST:/dev_mgr/reconfigure
    * @secure
    */
-  export namespace SynchronizeDetail {
+  export namespace ReconfigureCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = IdObject;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.dev_mgr.dhcpinfo.create` The provisioning server either creates a new device or changes the information of the device with the same MAC address
+   * @tags devices
+   * @name DhcpinfoCreate
+   * @summary Push DHCP request information
+   * @request POST:/dev_mgr/dhcpinfo
+   * @secure
+   */
+  export namespace DhcpinfoCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = DHCPInfoObject;
+    export type RequestHeaders = {
+      /** The tenant's UUID, defining the ownership of a given resource */
+      "Wazo-Tenant"?: string;
+    };
+    export type ResponseBody = any;
+  }
+}
+
+export namespace CfgMgr {
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.read` The configuration manager resource represents the entry point to the wazo-provd configuration REST API
+   * @tags configs
+   * @name CfgMgrList
+   * @summary Get the Config Manager resource
+   * @request GET:/cfg_mgr
+   * @secure
+   */
+  export namespace CfgMgrList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = CfgMgrListData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.read`
+   * @tags configs
+   * @name ConfigsList
+   * @summary List and find configurations
+   * @request GET:/cfg_mgr/configs
+   * @secure
+   */
+  export namespace ConfigsList {
+    export type RequestParams = {};
+    export type RequestQuery = {
+      /**
+       * A list of fields, separated by comma.
+       *
+       * Example: `mac,ip`
+       */
+      fields?: string;
+      /**
+       * A selector, encoded in JSON, describing which entries should be returned. All entries are returned if not specified.
+       *
+       * Example: `{"ip":"10.34.1.110"}`
+       */
+      q?: string;
+      /**
+       * An integer specifing the number of entries to skip.
+       *
+       * Example: 10
+       */
+      skip?: number;
+      /**
+       * The key on which to sort the results.
+       *
+       * Example: `id`
+       */
+      sort?: string;
+      /** The order of sort */
+      sort_ord?: "ASC" | "DESC";
+    };
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ConfigsObject;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.create`
+   * @tags configs
+   * @name ConfigsCreate
+   * @summary Create a configuration
+   * @request POST:/cfg_mgr/configs
+   * @secure
+   */
+  export namespace ConfigsCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = ConfigObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = IdObject;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.read`
+   * @tags configs
+   * @name ConfigsDetail
+   * @summary Get a configuration
+   * @request GET:/cfg_mgr/configs/{config_id}
+   * @secure
+   */
+  export namespace ConfigsDetail {
     export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
+      /** Configuration ID */
+      configId: string;
     };
     export type RequestQuery = {};
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = SynchronizeDetailData;
+    export type ResponseBody = ConfigObject;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.update`
+   * @tags configs
+   * @name ConfigsUpdate
+   * @summary Update a configuration
+   * @request PUT:/cfg_mgr/configs/{config_id}
+   * @secure
+   */
+  export namespace ConfigsUpdate {
+    export type RequestParams = {
+      /** Configuration ID */
+      configId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = ConfigObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.delete`
+   * @tags configs
+   * @name ConfigsDelete
+   * @summary Delete a configuration
+   * @request DELETE:/cfg_mgr/configs/{config_id}
+   * @secure
+   */
+  export namespace ConfigsDelete {
+    export type RequestParams = {
+      /** Configuration ID */
+      configId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.configs.{config_id}.raw.read`
+   * @tags configs
+   * @name ConfigsRawList
+   * @summary Get a raw configuration
+   * @request GET:/cfg_mgr/configs/{config_id}/raw
+   * @secure
+   */
+  export namespace ConfigsRawList {
+    export type RequestParams = {
+      /** Configuration ID */
+      configId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ConfigsRawListData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.cfg_mgr.autocreate.create` Create a new config based on the config that has the autocreate role
+   * @tags configs
+   * @name AutocreateCreate
+   * @summary Create an autocreate configuration
+   * @request POST:/cfg_mgr/autocreate
+   * @secure
+   */
+  export namespace AutocreateCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = EmptyObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = IdObject;
   }
 }
 
@@ -984,232 +984,6 @@ export namespace PgMgr {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = PgMgrListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.read`
-   * @tags plugins
-   * @name InstallList
-   * @summary Get the installation service resources
-   * @request GET:/pg_mgr/install
-   * @secure
-   */
-  export namespace InstallList {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.install.create`
-   * @tags plugins
-   * @name InstallInstallCreate
-   * @summary Install a plugin
-   * @request POST:/pg_mgr/install/install
-   * @secure
-   */
-  export namespace InstallInstallCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = IdObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
-   * @tags plugins
-   * @name InstallInstallDelete
-   * @summary Delete the Operation In Progress
-   * @request DELETE:/pg_mgr/install/install/{operation_id}
-   * @secure
-   */
-  export namespace InstallInstallDelete {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.read`
-   * @tags plugins
-   * @name InstallInstallDetail
-   * @summary Get the status of a plugin installation Operation In Progress
-   * @request GET:/pg_mgr/install/install/{operation_id}
-   * @secure
-   */
-  export namespace InstallInstallDetail {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallInstallDetailData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.installable.read`
-   * @tags plugins
-   * @name InstallInstallableList
-   * @summary Get the installable plugins list
-   * @request GET:/pg_mgr/install/installable
-   * @secure
-   */
-  export namespace InstallInstallableList {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallInstallableListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.installed.read`
-   * @tags plugins
-   * @name InstallInstalledList
-   * @summary Get the installed plugins list
-   * @request GET:/pg_mgr/install/installed
-   * @secure
-   */
-  export namespace InstallInstalledList {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallInstalledListData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.uninstall.create`
-   * @tags plugins
-   * @name InstallUninstallCreate
-   * @summary Uninstall a plugin
-   * @request POST:/pg_mgr/install/uninstall
-   * @secure
-   */
-  export namespace InstallUninstallCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = IdObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.update.create`
-   * @tags plugins
-   * @name InstallUpdateCreate
-   * @summary Update the List of installable plugins
-   * @request POST:/pg_mgr/install/update
-   * @secure
-   */
-  export namespace InstallUpdateCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = EmptyObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
-   * @tags plugins
-   * @name InstallUpdateDelete
-   * @summary Delete the Operation In Progress
-   * @request DELETE:/pg_mgr/install/update/{operation_id}
-   * @secure
-   */
-  export namespace InstallUpdateDelete {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.read`
-   * @tags plugins
-   * @name InstallUpdateDetail
-   * @summary Get the status of a plugin database update Operation In Progress
-   * @request GET:/pg_mgr/install/update/{operation_id}
-   * @secure
-   */
-  export namespace InstallUpdateDetail {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallUpdateDetailData;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.pg_mgr.install.upgrade.create`
-   * @tags plugins
-   * @name InstallUpgradeCreate
-   * @summary Upgrade a plugin
-   * @request POST:/pg_mgr/install/upgrade
-   * @secure
-   */
-  export namespace InstallUpgradeCreate {
-    export type RequestParams = {};
-    export type RequestQuery = {};
-    export type RequestBody = IdObject;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
-   * @tags plugins
-   * @name InstallUpgradeDelete
-   * @summary Delete the Operation In Progress
-   * @request DELETE:/pg_mgr/install/upgrade/{operation_id}
-   * @secure
-   */
-  export namespace InstallUpgradeDelete {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = any;
-  }
-
-  /**
-   * @description **Required ACL:** `provd.operation.read`
-   * @tags plugins
-   * @name InstallUpgradeDetail
-   * @summary Get the status of a plugin upgrade Operation In Progress
-   * @request GET:/pg_mgr/install/upgrade/{operation_id}
-   * @secure
-   */
-  export namespace InstallUpgradeDetail {
-    export type RequestParams = {
-      /** Operation In Progress ID */
-      operationId: string;
-    };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = InstallUpgradeDetailData;
   }
 
   /**
@@ -1305,6 +1079,27 @@ export namespace PgMgr {
   }
 
   /**
+   * @description **Required ACL:** `provd.operation.read`
+   * @tags plugins
+   * @name PluginsInstallInstallDetail
+   * @summary Get the status of a package installation Operation In Progress
+   * @request GET:/pg_mgr/plugins/{plugin_id}/install/install/{operation_id}
+   * @secure
+   */
+  export namespace PluginsInstallInstallDetail {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+      /** Plugin ID */
+      pluginId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = PluginsInstallInstallDetailData;
+  }
+
+  /**
    * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
    * @tags plugins
    * @name PluginsInstallInstallDelete
@@ -1326,14 +1121,33 @@ export namespace PgMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.operation.read`
+   * @description **Required ACL:** `provd.pg_mgr.plugins.{plugin_id}.install.uninstall.create`
    * @tags plugins
-   * @name PluginsInstallInstallDetail
-   * @summary Get the status of a package installation Operation In Progress
-   * @request GET:/pg_mgr/plugins/{plugin_id}/install/install/{operation_id}
+   * @name PluginsInstallUninstallCreate
+   * @summary Uninstall a package
+   * @request POST:/pg_mgr/plugins/{plugin_id}/install/uninstall
    * @secure
    */
-  export namespace PluginsInstallInstallDetail {
+  export namespace PluginsInstallUninstallCreate {
+    export type RequestParams = {
+      /** Plugin ID */
+      pluginId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = IdObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.read`
+   * @tags plugins
+   * @name PluginsInstallUpgradeDetail
+   * @summary Get the status of a package upgrade Operation In Progress
+   * @request GET:/pg_mgr/plugins/{plugin_id}/install/upgrade/{operation_id}
+   * @secure
+   */
+  export namespace PluginsInstallUpgradeDetail {
     export type RequestParams = {
       /** Operation In Progress ID */
       operationId: string;
@@ -1343,7 +1157,28 @@ export namespace PgMgr {
     export type RequestQuery = {};
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = PluginsInstallInstallDetailData;
+    export type ResponseBody = PluginsInstallUpgradeDetailData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
+   * @tags plugins
+   * @name PluginsInstallUpgradeDelete
+   * @summary Delete the Operation In Progress
+   * @request DELETE:/pg_mgr/plugins/{plugin_id}/install/upgrade/{operation_id}
+   * @secure
+   */
+  export namespace PluginsInstallUpgradeDelete {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+      /** Plugin ID */
+      pluginId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
   }
 
   /**
@@ -1385,18 +1220,31 @@ export namespace PgMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.pg_mgr.plugins.{plugin_id}.install.uninstall.create`
+   * @description **Required ACL:** `provd.pg_mgr.install.read`
    * @tags plugins
-   * @name PluginsInstallUninstallCreate
-   * @summary Uninstall a package
-   * @request POST:/pg_mgr/plugins/{plugin_id}/install/uninstall
+   * @name InstallList
+   * @summary Get the installation service resources
+   * @request GET:/pg_mgr/install
    * @secure
    */
-  export namespace PluginsInstallUninstallCreate {
-    export type RequestParams = {
-      /** Plugin ID */
-      pluginId: string;
-    };
+  export namespace InstallList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = InstallListData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.pg_mgr.install.install.create`
+   * @tags plugins
+   * @name InstallInstallCreate
+   * @summary Install a plugin
+   * @request POST:/pg_mgr/install/install
+   * @secure
+   */
+  export namespace InstallInstallCreate {
+    export type RequestParams = {};
     export type RequestQuery = {};
     export type RequestBody = IdObject;
     export type RequestHeaders = {};
@@ -1404,19 +1252,36 @@ export namespace PgMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
+   * @description **Required ACL:** `provd.operation.read`
    * @tags plugins
-   * @name PluginsInstallUpgradeDelete
-   * @summary Delete the Operation In Progress
-   * @request DELETE:/pg_mgr/plugins/{plugin_id}/install/upgrade/{operation_id}
+   * @name InstallInstallDetail
+   * @summary Get the status of a plugin installation Operation In Progress
+   * @request GET:/pg_mgr/install/install/{operation_id}
    * @secure
    */
-  export namespace PluginsInstallUpgradeDelete {
+  export namespace InstallInstallDetail {
     export type RequestParams = {
       /** Operation In Progress ID */
       operationId: string;
-      /** Plugin ID */
-      pluginId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = InstallInstallDetailData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
+   * @tags plugins
+   * @name InstallInstallDelete
+   * @summary Delete the Operation In Progress
+   * @request DELETE:/pg_mgr/install/install/{operation_id}
+   * @secure
+   */
+  export namespace InstallInstallDelete {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
     };
     export type RequestQuery = {};
     export type RequestBody = never;
@@ -1425,24 +1290,159 @@ export namespace PgMgr {
   }
 
   /**
-   * @description **Required ACL:** `provd.operation.read`
+   * @description **Required ACL:** `provd.pg_mgr.install.uninstall.create`
    * @tags plugins
-   * @name PluginsInstallUpgradeDetail
-   * @summary Get the status of a package upgrade Operation In Progress
-   * @request GET:/pg_mgr/plugins/{plugin_id}/install/upgrade/{operation_id}
+   * @name InstallUninstallCreate
+   * @summary Uninstall a plugin
+   * @request POST:/pg_mgr/install/uninstall
    * @secure
    */
-  export namespace PluginsInstallUpgradeDetail {
+  export namespace InstallUninstallCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = IdObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.pg_mgr.install.upgrade.create`
+   * @tags plugins
+   * @name InstallUpgradeCreate
+   * @summary Upgrade a plugin
+   * @request POST:/pg_mgr/install/upgrade
+   * @secure
+   */
+  export namespace InstallUpgradeCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = IdObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.read`
+   * @tags plugins
+   * @name InstallUpgradeDetail
+   * @summary Get the status of a plugin upgrade Operation In Progress
+   * @request GET:/pg_mgr/install/upgrade/{operation_id}
+   * @secure
+   */
+  export namespace InstallUpgradeDetail {
     export type RequestParams = {
       /** Operation In Progress ID */
       operationId: string;
-      /** Plugin ID */
-      pluginId: string;
     };
     export type RequestQuery = {};
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = PluginsInstallUpgradeDetailData;
+    export type ResponseBody = InstallUpgradeDetailData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
+   * @tags plugins
+   * @name InstallUpgradeDelete
+   * @summary Delete the Operation In Progress
+   * @request DELETE:/pg_mgr/install/upgrade/{operation_id}
+   * @secure
+   */
+  export namespace InstallUpgradeDelete {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.pg_mgr.install.update.create`
+   * @tags plugins
+   * @name InstallUpdateCreate
+   * @summary Update the List of installable plugins
+   * @request POST:/pg_mgr/install/update
+   * @secure
+   */
+  export namespace InstallUpdateCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = EmptyObject;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.read`
+   * @tags plugins
+   * @name InstallUpdateDetail
+   * @summary Get the status of a plugin database update Operation In Progress
+   * @request GET:/pg_mgr/install/update/{operation_id}
+   * @secure
+   */
+  export namespace InstallUpdateDetail {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = InstallUpdateDetailData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.operation.delete` This does not cancel the underlying operation; it only deletes the monitor Every monitor that is created should be deleted, else they won't be freed by the process and they will accumulate, taking memory
+   * @tags plugins
+   * @name InstallUpdateDelete
+   * @summary Delete the Operation In Progress
+   * @request DELETE:/pg_mgr/install/update/{operation_id}
+   * @secure
+   */
+  export namespace InstallUpdateDelete {
+    export type RequestParams = {
+      /** Operation In Progress ID */
+      operationId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.pg_mgr.install.installable.read`
+   * @tags plugins
+   * @name InstallInstallableList
+   * @summary Get the installable plugins list
+   * @request GET:/pg_mgr/install/installable
+   * @secure
+   */
+  export namespace InstallInstallableList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = InstallInstallableListData;
+  }
+
+  /**
+   * @description **Required ACL:** `provd.pg_mgr.install.installed.read`
+   * @tags plugins
+   * @name InstallInstalledList
+   * @summary Get the installed plugins list
+   * @request GET:/pg_mgr/install/installed
+   * @secure
+   */
+  export namespace InstallInstalledList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = InstallInstalledListData;
   }
 
   /**

--- a/src/schemas/webhookd.ts
+++ b/src/schemas/webhookd.ts
@@ -145,6 +145,7 @@ export type StatusListData = StatusSummary;
 export interface StatusSummary {
   bus_consumer?: ComponentWithStatus;
   master_tenant?: ComponentWithStatus;
+  [key: string]: any;
 }
 
 export enum StatusValue {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are auto-generated type definitions with no runtime logic; the main consumer impact is adopting new optional APIs or updating SAML logout clients to match query-param typing.
> 
> **Overview**
> Regenerates the **swagger-typescript-api** schema modules to match Wazo **26.04.1**, exposing new and updated REST contracts across several services.
> 
> **agentd** adds per-queue agent login/logoff (`PUT /agents/{agent_id}/queues/{queue_id}/login|logoff`) and an optional `all_queues` flag on `POST /agents/relog` to restore queue membership after individual logoffs.
> 
> **auth** (and **authPortal**) gains typed user external integrations for **Google**, **Microsoft**, and **mobile** push (FCM/APNs tokens, sender id). SAML logout response handling is modeled as **query parameters** (`RelayState`, `SAMLResponse`) on `GET /saml/sls` instead of a request body.
> 
> **chatd** adds connector discovery, auth schemas, inbound webhooks, tenant/user **identity** CRUD, optional `identity` on room users, `sender_identity_uuid` on outbound messages, and **delivery** metadata on messages.
> 
> **calld** adds tenant-wide `GET /voicemails/messages` with filters (transcription, user, voicemail type) and transcription fields on voicemail message types; **confd** adds `mobile_fallback_enabled` on users, `GET/PUT /voicemails/transcription`, and `caller_id_name` on caller ID settings.
> 
> **callLogd** extends agent statistics with `answered` and per-**queue** breakdowns; CDR and list-parameter docs are aligned with CDR semantics. Remaining edits are mostly OpenAPI doc/tag/header tweaks (**confdPortal** `Wazo-Tenant` optional, filter descriptions, **dird** auth config typing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09f841d539e06409ecd243d94632b273bcfd809. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->