### PR TITLE
Update/fix Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
       id-token: write # Required for OIDC trusted publishing
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/node": "^22.15.1",
     "dotenv": "^17.2.3",
     "jest": "^29.7.0",
-    "node": "^22.15.1",
     "swagger-typescript-api": "^13.1.3",
     "ts-jest": "^29.3.4",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.19)
-      node:
-        specifier: ^22.15.1
-        version: 22.15.1
       swagger-typescript-api:
         specifier: ^13.1.3
         version: 13.1.3
@@ -1000,9 +997,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-bin-setup@1.1.4:
-    resolution: {integrity: sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==}
-
   node-fetch-h2@2.3.0:
     resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
     engines: {node: 4.x || >=6.0.0}
@@ -1027,11 +1021,6 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-
-  node@22.15.1:
-    resolution: {integrity: sha512-fVMOwAjiig0JqRACMgoKUPydhOTaMh3jCJn+aeFU5u7XCCYkvjQ8H5B6L8c26ruKHkDm66a9QDMDkR3CQ78I+A==}
-    engines: {npm: '>=5.0.0'}
-    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2652,8 +2641,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-bin-setup@1.1.4: {}
-
   node-fetch-h2@2.3.0:
     dependencies:
       http2-client: 1.3.5
@@ -2671,10 +2658,6 @@ snapshots:
       es6-promise: 3.3.1
 
   node-releases@2.0.19: {}
-
-  node@22.15.1:
-    dependencies:
-      node-bin-setup: 1.1.4
 
   normalize-path@3.0.0: {}
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -52,7 +52,7 @@ Promise.all(
   }),
 ).then(() => {
   exec(
-    'docker run --rm -v $(pwd):/app -w /app node:22-slim bash scripts/fix-types.sh',
+    'bash scripts/fix-types.sh',
     (error, _stdout, stderr) => {
       if (error) {
         console.error(`❌ Error while running 'fix-types.sh': ${error.message}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and local build tooling only; no runtime API or library behavior changes.
> 
> **Overview**
> **Bumps CI action versions** in `main.yml` and `release.yml`: `actions/checkout` v5, `pnpm/action-setup` v6, and `actions/setup-node` v5.
> 
> **Simplifies the generate pipeline** by running `scripts/fix-types.sh` directly on the host instead of wrapping it in `docker run ... node:22-slim`, and drops the `node` npm devDependency (and related lockfile entries) that supported the Docker-based approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f8d8bb6756d8901f9766aeb4901a1f91dfdb53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->